### PR TITLE
Added many photos and a few blog posts

### DIFF
--- a/fragforce/pages/blog/2017/09/herndon_fec_photos.html
+++ b/fragforce/pages/blog/2017/09/herndon_fec_photos.html
@@ -1,6 +1,6 @@
 title: Herndon's Original Fragforce Elder Council Photos
 pagetitle: Herndon's Original Fragforce Elder Council Photos
-date: 2017-09-23
+date: 2017-09-29
 author: Paulson McIntyre
 tags: fragforce
 published: true

--- a/fragforce/pages/blog/2017/09/herndon_fec_photos.html
+++ b/fragforce/pages/blog/2017/09/herndon_fec_photos.html
@@ -1,0 +1,12 @@
+title: Herndon's Original Fragforce Elder Council Photos
+pagetitle: Herndon's Original Fragforce Elder Council Photos
+date: 2017-09-23
+author: Paulson McIntyre
+tags: fragforce
+published: true
+all_images: true
+
+A few random photos of the [Fragforce][FF] Elder Council from back in March 2016. This was before lots of other sites
+joined and the Fragforce Elder Council expanded.
+
+[FF]: https://fragforce.org

--- a/fragforce/pages/blog/2017/09/herndon_streaming.html
+++ b/fragforce/pages/blog/2017/09/herndon_streaming.html
@@ -1,0 +1,11 @@
+title: Herndon Streaming System
+pagetitle: Herndon Streaming Room
+date: 2017-09-29
+author: Paulson McIntyre
+tags: fragforce
+published: true
+all_images: true
+
+The [Fragforce][FF] streaming setup used on 2017-08-04 and 2017-08-05 consisted of a green screen for chroma key, various streaming computers, and 4k SOHO camera with HDMI-to-USB encoder. The setup combined with green gaffers tape allowed for some fun, on stream effects.
+
+[FF]: https://fragforce.org

--- a/fragforce/pages/events/2017/02/Herndon-28.html
+++ b/fragforce/pages/events/2017/02/Herndon-28.html
@@ -1,0 +1,12 @@
+title: FML @ Herndon
+pagetitle: FML @ Herndon
+date: 2017-02-28
+start_time: 5:00 p.m.
+start_location: the main kitchen
+number_days: 1
+hours_per_day: 3
+tags: virginia, usa
+address: 2550 Wasser Terrace Herndon, VA 20171
+published: true
+
+The first FML event! This is a weekly Fragforce board gaming event on Wednesday evenings at the Herndon office!

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0530.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0530.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9bae38c38956d8e89d00105d735e013e25c05457fb5d6abbaf9fcaad003528e
+size 3217695

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0534.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0534.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:255d318ef1d9d65056675ff0db786f5e570b831e87298da72d14a1a264bd93d2
+size 3326925

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0537.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0537.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7de92e2f2601f6236eb780051bb8467710d0ef6cb1980b37f58c448e41ecd01a
+size 3294346

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0543.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0543.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a656aa3f0cec1a07f8d9465d896a870ccf6f8ee07c4eee6a12f1beb26ae185aa
+size 3205368

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0544.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0544.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dfc46a30f2c4b948bac1509169fca488a8586ed8726835bffe47378f752a4a5
+size 3251473

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0547.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0547.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0b44d9eee95b892c609bb20573e53cc85c68612965b795c13c8b079cc0ac68c
+size 3268867

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0549.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0549.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3a406aba9efaa1769ccf7b4e39fa623a8b1ce1611e5603847aa7ca514ebd108
+size 1728410

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0556.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0556.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b1dcfb8d078c19140c1d837f3629ef5878af6a957a7c7f6861d52960a0f2d12
+size 3686876

--- a/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0558.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_fec_photos/20160331-DSC_0558.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8084e85a8c584c35429ca0af1e7364675df9224f3f74bec2ff4378104ec0c7cc
+size 4006628

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2711.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2711.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7412e377583e492e89cfe63868a7bfdff15b656e5f3ed0b9a771beec559d520c
+size 3939502

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2721.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2721.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:082dbfd9a5c07ee9d5419c58a5fb75a111400374db51465942da355f73352a2e
+size 4158565

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2722.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2722.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a08aa4c337ae1c1e5efc75c86b03edbab3ec590ae298c9d9d8e11519d0af6938
+size 3519584

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2727.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2727.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:769e2a95fbcf19e24f95bf2c95acdfaef31e6134983b5583e172110bfd4dd415
+size 3860192

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2740.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2740.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53024a5495b84b269e7a7931354d2afa3fe1ea16c97f3f1a4ec6d32c6c4ad794
+size 4095699

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2747.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2747.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:964b60d75d5e88e3b5c98f1d0a94cdbc807d0a5ee008e2b1c8d8dec5f9324cf2
+size 3374795

--- a/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2750.jpg
+++ b/fragforce/static/images/blog/2017/09/herndon_streaming/Fragforce-20170805-DSC_2750.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee3baa1fa8afa24b6da2da0d583e0fc26e87b9b555f6845231fc414766ce6faa
+size 3272510

--- a/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161104-DSCF5906.jpg
+++ b/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161104-DSCF5906.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e6ab1e5c4706d0905016ca4ba66f6e30fccf3abacbce93651efc17a29bb52d7
+size 3072652

--- a/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161105-DSCF7957.jpg
+++ b/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161105-DSCF7957.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a0f80ac17329a38aafe7f7b27554a515fa2e08d74feab861da5a93d02f6cfc4
+size 3127427

--- a/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161105-DSCF8062.jpg
+++ b/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161105-DSCF8062.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:833bf4919d11573d7c1706159574b14dafae79cc3f457549998b45904462b823
+size 1681612

--- a/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161105-DSCF8119.jpg
+++ b/fragforce/static/images/events/2016/11/Herndon/Fragforce-2016-11-05-20161105-DSCF8119.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2a328d9f296f769ede754166fe387ddb76aa6269fa35c0eb899b1b7fffc9e3d
+size 2611665

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161110-DSCF8147.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161110-DSCF8147.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8e06a765ae14106ce77bdc2d01f26adcbf793c21730cc6c5777e4e1eff4bcc8
+size 4084897

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161110-DSCF8154.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161110-DSCF8154.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c0d11b62cab0aa8f8485d6b6fc9d7c5a9f305e5021f79777e7d8e7bc43742ae
+size 4139517

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8490.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8490.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1acfdd4069857bf5fbe028a8010b786abd75a75e547bcee91c2c659d839c4715
+size 2791201

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8492.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8492.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce79ec262917b1e2995744a4e859d9b0b62dd5c29a9c2050d1e5afb399316156
+size 2655342

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8517.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8517.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:167003aa38e5ca4dc6bc9d626280c78bd0b45aeed601dd57f8b0a3fe440d5264
+size 346999

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8529.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8529.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8efb7124e9b4c46761fe5acae517e02c1899aaa509ada315b1ea340632fafde0
+size 2650921

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8534.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161111-DSCF8534.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72b9fc2656b4a150fdf8d4d36b3f76e16974157616e0b8f9621ad3b72a8dc1f8
+size 4165742

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8758.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8758.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b7410d2a0ea8d749b20a710da2f2d9ae944ba9cf503ba104030476d6f02e1a6
+size 2981001

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8761.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8761.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eae290ef93d1948d663a736aae58b874636816e5ca56d3b0b60a9751f0d16612
+size 3002655

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8787.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8787.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e127642040dd19bbe4ba1903d671290bdaa348b5578340c310bc5568be0578f4
+size 2814940

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8791.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8791.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c60b2cfb8a159ba151baf00ec32f118ea45ad72d7e6885a3b7706dff81e5413e
+size 2792112

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8813.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8813.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b704769ac3cdb0d99eddaf464cd000ede652370210f680460874a7a65e8eea3b
+size 2964371

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8987.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF8987.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32b2e825b15cc52e955db619bfb14ad4e963f9842974d94d0d61cd896c0e7094
+size 3256562

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF9038.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF9038.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c81724d0a3a5ddff0cbde7f56c80e0db59cfdf5f8330030b2c7109373e54078
+size 2675373

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF9136.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161112-DSCF9136.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8422fce4f8dee1080c7d11292908e2e4547ffcfebfff0404bb532665276b25f4
+size 2928747

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9168.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9168.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a8a294daa8b21c55a98f4161b6a54685fd85a23b6a3fff8648b0fd180bb9399
+size 3260317

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9170.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9170.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc90a47431675807d66fbcd8c012af077351a912815e6854d6052c7e4071c835
+size 3219387

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9171.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8faace4649d43a5a9ca7a2964433323688ef8825433c5b09fbedeeb15c13b0c1
+size 3119196

--- a/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9177.jpg
+++ b/fragforce/static/images/events/2016/11/UCSF/Fragforce 2016-11-11-20161113-DSCF9177.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dc2fddf38b279cf214b86b291015341b64b7c40aaa7b6e076e427233563762d
+size 3345297

--- a/fragforce/static/images/events/2017/02/Herndon-28/Fragforce-20170228-DSC_6381.jpg
+++ b/fragforce/static/images/events/2017/02/Herndon-28/Fragforce-20170228-DSC_6381.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30817b80df378c5bc39e80cba570450ffbe7ee81df358d94725114a5cba662b9
+size 3853670

--- a/fragforce/static/images/events/2017/02/Herndon-28/Fragforce-20170228-DSC_6473.jpg
+++ b/fragforce/static/images/events/2017/02/Herndon-28/Fragforce-20170228-DSC_6473.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bdadede809a3cb7a521073527d70ccdc5517a96b5092c0db8c1b0924948b431
+size 2872665

--- a/fragforce/static/images/events/2017/02/Herndon-28/Fragforce-20170228-DSC_6521.jpg
+++ b/fragforce/static/images/events/2017/02/Herndon-28/Fragforce-20170228-DSC_6521.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39eb46c5f85f959bb42584ee0edc17c292bf6b29bdc4b35e277ff95aa1ad2666
+size 3470027

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170803-DSC_1860.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170803-DSC_1860.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:351ba45ee46871b4cf34682134f5321dc618fcb3c6d66fd0951f641c7d7c6e60
+size 3202557

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170803-DSC_1864.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170803-DSC_1864.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:639e6b3e5f9ef4637972e6d150ce8495d8838e372f7e9e36ca2af74004e00fd0
+size 3197751

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170803-DSC_1866.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170803-DSC_1866.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3af2853f5203ac802daba2517878659c8aad5dae527ab5d2bfd259e1b2b7fd9
+size 2800701

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1870.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1870.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0afa2c832d1ddea0e193c10627433205a6d2581b1e213930a84f5ded48ad87ec
+size 4124711

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1874.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1874.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff540af358a981f46dccb8d69587257a8258e7fa722285f4f0dd0fc84fe59085
+size 3871364

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1877.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1877.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97d74809d16c100e596933391c0ade915e1561330e63d0cc374ae11a5340e98f
+size 3166242

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1904.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1904.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97288f009e188b5212a4dab26a5fc6a8e1bcbf9bb4075282e61e5d06a7b4bbcb
+size 3859105

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1909.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_1909.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9705e8fea06524b977b3c11e22eb7cf0012d905216604e219b56024fa0993370
+size 4039164

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2021.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2021.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a1aec7df65f785be3746fa9ecc055bc916118b41f0946b515401b7a237f54d9
+size 3641088

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2074.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2074.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82d9f29630490cec6ae6bd1a12b44554cece4d02594b3064fde7ae09101d0a8
+size 3275678

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2093.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2093.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a602199f696ba6fc3dab285160514bda176d9478eda528d1b45e34b12484b32
+size 3644360

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2103.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2103.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cbed90a58797ca988d54b024e00f1ecc09d06c8627c24fc0aaae3fd40ae52d0
+size 3155866

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2136.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2136.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:051db2db539ed87b97ef7a19ff8cab2b8df9116e39fdfd75a8362712cab3f475
+size 3234651

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2156.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2156.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d02c25c40f6fbefe5e4324bf141ece1931373b206ff0a9b791f821f7cefeff8
+size 4106930

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2190.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2190.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71ede6fce36e04e0a43fab34e9bd6c9c23088ab8e376b6db7fd57be7eaedc4da
+size 3436705

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2262.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2262.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3de083e538fc4f787027813dd316c43ed938e17d86219ba478a629fb2dd79796
+size 3072356

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2280.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2280.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94b3626b9a536f978dbe94afac65b253193f95933659d04b217db437ca3cb751
+size 3008522

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2306-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2306-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f96ef574b58c11aaade7e13011ae0fc3d3ead2ce87f2d558d4ddcf62da6a4a1d
+size 3642506

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2308-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2308-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d374221e5ca06d522a63311a39afcfbc75b389a5a56801d0f1b4301c0e892181
+size 2946617

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2311-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2311-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5939926d24fa91754250ecb499b51efe5369e63d8c81b59007550fddff41fb4
+size 2986028

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2318-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2318-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e3f88f88f56d6464ff8b5460737175cd33008baecf50c3739f9d85871f19aa2
+size 3825496

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2328-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2328-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff1f38fa06df72d232d1358343e1228cbf96ba8cffb0f4f0c469771a354d75f4
+size 3945005

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2337-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2337-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ab1cd0fd0f2bc67b998e1fa83e6fde3c5e13bf7805aa85405b2ae0d257ab40
+size 3745339

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2371-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2371-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6462b45fe3384fde87db5ef4f911d6624b1ccf6d2788457b42136303c4713ae
+size 3758278

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2375.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2375.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3e54b00fe4e876601d28fb9d8fd5b2ae6027a2ad3508892dee8c0604f557185
+size 3480245

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2394-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2394-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79580fa5675f2bc015b5d0dea36e9c1ad20947010a2077d6e55b3912765fabfa
+size 3399932

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2400-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2400-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c60c62eda1e7aa0aea68d00ee5c5aa48ff60b631c7cd3abd76cf2f5ac446314
+size 2638848

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2425-2.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2425-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c10952d6c9b37aa8391bc607fbee7cb73fdb34ba64894d7bc07aa2f603f9ac63
+size 2852806

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2452.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2452.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15bef7f4346d7c5fd564f48d69b107c8f2d432ee24cb515c4c0f3821f79f7cd8
+size 3396325

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2455.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2455.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19f22cd6afabd2b23b5899270844df6183036eff1eb3f0695d0af77667c0787e
+size 3648383

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2601.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2601.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa7cb4fae17bb9716902a9deecc455043ec0853e7a05a0dcfcf527f96fb4cb0d
+size 2804487

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2610.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2610.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bd6fd5170206ba07d9c14342d15713d98c5fb2e6afb55f9ebecee0d321050d8
+size 3377555

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2630.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2630.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a585828ec7c9667aef89af06b468fcd8abe4cfabd8dac7a3a97ddf03c60f39e8
+size 3543834

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2702.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2702.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfdcf8542e5ad171ef9535b293ff4d829a75d27adb267af8960eb1442976ad43
+size 3314836

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2711.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2711.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d531ae2ddb53d483084f6dd59b77defd14e15f0995487ef71ab9025f1c4d5283
+size 3939502

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2715.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2715.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2267228b098783d763cac722d7db56d191b83950fea85f7ebb91cb6575255e25
+size 3861613

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2721.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2721.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc2c8edf8e5964295829555d299d40b97303d59eefc777519ce387fd523a2baa
+size 4158565

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2722.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2722.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15942567d1f4fe1d68ccdf95309b4ad252a2ae0996f203b0ca4d81467e15b421
+size 3519584

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2727.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2727.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09a3b409c93573f7051c2594b6a36225e74564e73aa8fb46a2c4998d050dd3fa
+size 3860192

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2740.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2740.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bee5a67fbbae8802efb012a2e88730a38dd99aef882d8bb91198c11d86a022b7
+size 4095699

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2747.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2747.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:004f91f5d017aa0597a0e877c31adb7f97f6ad8e999c96cd967cfce2be359045
+size 3374795

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2750.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2750.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d94d128fe045e6f0b5db11dbd8277d3351fcaf6233be76aa4011c57393e66eeb
+size 3272510

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2752.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2752.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d45b9697c57045e9bef955b675b9efffb4b34cc995115052b8488b020545f8d2
+size 3366539

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2756.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2756.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8ea01d01415ed4aafc2f0e957193a403e8c6d1ff780fe62a907a93cca25a40
+size 3884217

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2780.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2780.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0116c722cb04b2045ff3d731ea475c2768314f48b3eafcdc4c57f5fd769980c
+size 3579737

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2786.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2786.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6de36c431706472c429600b4ef2abb3875df40e9f5869701edc40ad353fa1fb8
+size 3946057

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2833.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2833.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1acde5d06e4a7d23ea77a04808e5fd0a513fbfbc2b85417105b47d966ca5b2d9
+size 2246476

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2834.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2834.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c3bf5b0e6d5de519cf92b5a01509f37c82258458cb3268a662c6bc1ce5d6e2f
+size 2613505

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2897.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2897.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1a289fbad7a34abf9b6bb07991e8930e5456409dd28db2b85e07f1dd0283ba9
+size 3232334

--- a/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2898.jpg
+++ b/fragforce/static/images/events/2017/08/Herndon/Fragforce-20170805-DSC_2898.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94ab14766a72e444f4d075473370c42247b9ac36d60d734ccf29fca9f5a407c3
+size 2898690


### PR DESCRIPTION
@AevumDecessus Some of the images aren't loading right for me. I'm pretty sure it's because Git LFS isn't setup right for my instance. We really need Git LFS due to the increasing number of photos. 

```
[2017-09-29 05:44:16,774] ERROR in app: Exception on /imgsizer/images/blog/2017/09/herndon_tabletop/20170923-Fragforce-2939.jpg [GET]
Traceback (most recent call last):
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/flask_images/core.py", line 372, in handle_request
    image = Image.open(path)
  File "/home/fragforce/apps/gpmidi.fragforce.org/env/local/lib/python2.7/site-packages/PIL/Image.py", line 2317, in open
    % (filename if filename else fp))
IOError: cannot identify image file u'/home/fragforce/apps/gpmidi.fragforce.org/fragforce/static/images/blog/2017/09/herndon_tabletop/20170923-Fragforce-2939.jpg'
```

```
pmcintyr@hub:/home/fragforce/logs$ cat /home/fragforce/apps/gpmidi.fragforce.org/fragforce/static/images/blog/2017/09/herndon_tabletop/20170923-Fragforce-2910.jpg
version https://git-lfs.github.com/spec/v1
oid sha256:95bbfe9affebbc1adb976ce5e5aa1a418bfbe6e721b62c64bd2abbc3b62b46d2
size 4038692
```