### PR TITLE
Removed dt from page title and event name

### DIFF
--- a/fragforce/templates/events/by_sfid.html
+++ b/fragforce/templates/events/by_sfid.html
@@ -1,6 +1,6 @@
 {% extends 'events/base.html' %}
-{% block title %}{{ event.name }} On {% autoescape false %}{{ event.event_start_date__c|localtime }}{% endautoescape %}{% endblock %}
-{% block pagetitle %}{{ event.name }} On {% autoescape false %}{{ event.event_start_date__c|localtime }}{% endautoescape %}{% endblock pagetitle %}
+{% block title %}{{ event.name }}{% endblock %}
+{% block pagetitle %}{{ event.name }}{% endblock pagetitle %}
 {% block content %}
 <div class="row">
     <div class="col-sm-10">

--- a/fragforce/templates/events/by_sfid.html
+++ b/fragforce/templates/events/by_sfid.html
@@ -1,6 +1,6 @@
 {% extends 'events/base.html' %}
-{% block title %}{{ event.name }} On {{ event.event_start_date__c|localtime }}{% endblock %}
-{% block pagetitle %}{{ event.name }} On {{ event.event_start_date__c|localtime }}{% endblock pagetitle %}
+{% block title %}{{ event.name }} On {% autoescape false %}{{ event.event_start_date__c|localtime }}{% endautoescape %}{% endblock %}
+{% block pagetitle %}{{ event.name }} On {% autoescape false %}{{ event.event_start_date__c|localtime }}{% endautoescape %}{% endblock pagetitle %}
 {% block content %}
 <div class="row">
     <div class="col-sm-10">


### PR DESCRIPTION
Fixes #153

Removed dt from page title and event name - was making it too long and added escaping issues