### PR TITLE
adding inline reference to font library in css

### DIFF
--- a/fragforce/static/css/main.css
+++ b/fragforce/static/css/main.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Press+Start+2P|Roboto+Slab|Source+Sans+Pro');
+
 * {
   font-family: 'Roboto Slab', sans-serif;
   color: #ffffff;


### PR DESCRIPTION
fonts don't show up properly without being installed, this will create a single call to google font api to pull down the resources as web fonts.