### PR TITLE
Updated campaign link for tiltify

### DIFF
--- a/ffsite/templates/ff/root/donate.html
+++ b/ffsite/templates/ff/root/donate.html
@@ -30,7 +30,7 @@
         <div>
             <ul>
                 <li>
-                    Go to the <a href="https://tiltify.com/+fragforce/fragforce-fy19">FY19 Campaign</a> and click
+                    Go to the <a href="https://tiltify.com/+fragforce/">Donation Page</a> and click
                     "Donate Now" button -- you can register on Tiltify or donate anonymously.
                 </li>
                 <li>Pay via PayPal.</li>


### PR DESCRIPTION
Page changed to https://tiltify.com/+fragforce/ which will dynamically go to the active campaign.