### PR TITLE
Fix `distinct` usage bug

### DIFF
--- a/ffdonations/tasks/donations.py
+++ b/ffdonations/tasks/donations.py
@@ -64,7 +64,7 @@ def update_donations_existing(self):
 
     ret = []
     for teamID in teamIDs:
-        ret.append(update_donations_if_needed_team.delay(teamID=teamID).id)
+        ret.append(update_donations_if_needed_team.delay(teamID=teamID['team']).id)
     for participantID in participantIDs:
         ret.append(update_donations_if_needed_participant.delay(participantID=participantID['participant']).id)
     return ret


### PR DESCRIPTION
`Task ffdonations.tasks.donations.update_donations_if_needed_team[1ca8eeb1-bdc8-453d-8707-5195858b54a3] raised unexpected: TypeError("Field 'id' expected a number but got {'team': 54054}.")`