### PR TITLE
Don't query teams and participants from prior years

### DIFF
--- a/ffdonations/tasks/donations.py
+++ b/ffdonations/tasks/donations.py
@@ -88,11 +88,16 @@ def update_donations_if_needed_team(self, teamID):
 
     minc = timezone.now() - settings.EL_DON_TEAM_UPDATE_FREQUENCY_MIN
     maxc = timezone.now() - settings.EL_DON_TEAM_UPDATE_FREQUENCY_MAX
+    minTeamID = settings.MIN_EL_TEAMID
 
     if DonationModel.objects.all().count() <= 0:
         return doupdate()
 
     bfilter = DonationModel.objects.filter(team=team)
+
+    # Don't query any team with an id < MIN_EL_TEAMID, as those are from prior years
+    if teamID < minTeamID:
+        return None
 
     # Only force this if there are known donations but none in DB
     # Don't simplify to != as this could cause trashing if team update is behind the donations
@@ -182,6 +187,12 @@ def update_donations_if_needed_participant(self, participantID):
 
     minc = timezone.now() - settings.EL_DON_PTCP_UPDATE_FREQUENCY_MIN
     maxc = timezone.now() - settings.EL_DON_PTCP_UPDATE_FREQUENCY_MAX
+    minParticipantID = settings.MIN_EL_PARTICIPANTID
+
+    # Do not poll the api for participant IDs that are less than our min value
+    # These correspond to participant ids from previous years, and are not valid anymore
+    if participantID < minParticipantID:
+        return None
 
     if DonationModel.objects.all().count() <= 0:
         return doupdate()

--- a/fforg/settings.py
+++ b/fforg/settings.py
@@ -256,6 +256,11 @@ VIEW_SITE_EVENT_CACHE = int(os.environ.get('VIEW_SITE_EVENT_CACHE', 60))
 VIEW_SITE_SITE_CACHE = int(os.environ.get('VIEW_SITE_SITE_CACHE', 60))
 VIEW_SITE_STATIC_CACHE = int(os.environ.get('VIEW_SITE_STATIC_CACHE', 300))
 
+# Extra Life Limits and Data
+EXTRALIFE_TEAMID = int(os.environ.get('EXTRALIFE_TEAMID', 55801))
+MIN_EL_TEAMID = int(os.environ.get('MIN_EL_TEAMID', 55378))
+MIN_EL_PARTICIPANTID = int(os.environ.get('MIN_EL_PARTICIPANTID', 448472))
+
 # Min time between team updates - Only cares about tracked teams!
 EL_TEAM_UPDATE_FREQUENCY_MIN = timedelta(seconds=int(os.environ.get('EL_TEAM_UPDATE_FREQUENCY_MIN', 15)))
 # Max time between updates for any given team - Only cares about tracked teams!


### PR DESCRIPTION
Actually use those MIN_EL_TEAMID and MIN_EL_PARTICIPANTID values we have in heroku