### PR TITLE
Reorder donation checks

### DIFF
--- a/ffdonations/tasks/teams.py
+++ b/ffdonations/tasks/teams.py
@@ -30,15 +30,15 @@ def update_teams_if_needed(self):
 
     bq = TeamModel.objects.filter(tracked=True)
 
-    # Force an update if it's been more than EL_TEAM_UPDATE_FREQUENCY_MAX since last
-    # update for any record
-    if bq.filter(last_updated__lte=maxc).count() > 0:
-        return doupdate()
-
     # Skip updating if it's been less than EL_TEAM_UPDATE_FREQUENCY_MIN since last update
     # for any record
     if bq.filter(last_updated__gte=minc).count() > 0:
         return None
+
+    # Force an update if it's been more than EL_TEAM_UPDATE_FREQUENCY_MAX since last
+    # update for any record
+    if bq.filter(last_updated__lte=maxc).count() > 0:
+        return doupdate()
 
     # Guess we'll do an update!
     return doupdate()


### PR DESCRIPTION
* First check for min IDs, always skip those too high before any other
checks
* Second always check min_time between checks, honor those first
* Check numDonations against our list of donations to trigger an update
* Don't force an update if there are no donations for a team/partcipant,
covered by previous check
* Don't update by default every time if previous checks don't cover