### PR TITLE
Added A Check For EL Updates - Must Be Tracked Event

### DIFF
--- a/ffdonations/models.py
+++ b/ffdonations/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import Q
 from django.contrib.postgres.fields import HStoreField
 
+
 ## Extra-Life
 class EventModel(models.Model):
     # Ours

--- a/ffdonations/urls.py
+++ b/ffdonations/urls.py
@@ -18,7 +18,7 @@ from django.urls import path
 from ffdonations.views import *
 
 urlpatterns = [
-    # Test stuff
+    # Test stuff - Only enabled if DEBUG=True
     path('test', v_testView, name='testview'),
     path('update/force', v_forceUpdate, name='force-update'),
     # Teams

--- a/ffdonations/utils.py
+++ b/ffdonations/utils.py
@@ -121,3 +121,13 @@ def childsplay_donation_stats():
         supportingAmountRaised=float(raised.get('supporting', 0) or 0),
         amountRaised=float(raised.get('amount', 0) or 0),
     )
+
+
+@memoize(timeout=3600)
+def current_el_events():
+    """ Gets a list of valid events """
+    ret=set([e.id for e in EventModel.objects.filter(tracked=True).all()])
+
+    ret.add(TeamModel.objects.get(id=settings.EXTRALIFE_TEAMID).event_id)
+
+    return list(ret)


### PR DESCRIPTION
Only do updates for tracked events or the event for the current tracked team. Should greatly reduce celery, pg, redis, and EL load. 