### PR TITLE
Updated workflows to use node20 instead of node16

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -20,7 +20,7 @@ jobs:
         dockerfile: [ "web", "worker", "beat" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Debug
@@ -28,13 +28,13 @@ jobs:
           echo "github.ref -> {{ github.ref }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMG_NAME }}-${{ matrix.dockerfile }}
           tags: |
@@ -45,14 +45,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.${{ matrix.dockerfile }}
@@ -60,7 +60,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
       - name: Deploy
-        uses: darnfish/watchtower-update@v3.2
+        uses: darnfish/watchtower-update@v3.3
         with:
           url: "${{ secrets.WATCHTOWER_URL }}"
           api_token: "${{ secrets.WATCHTOWER_API_TOKEN }}"

--- a/.github/workflows/prod-images.yaml
+++ b/.github/workflows/prod-images.yaml
@@ -22,7 +22,7 @@ jobs:
         dockerfile: [ "web", "worker", "beat" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Debug
@@ -30,13 +30,13 @@ jobs:
           echo "github.ref -> {{ github.ref }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMG_NAME }}-${{ matrix.dockerfile }}
           tags: |
@@ -47,14 +47,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.${{ matrix.dockerfile }}


### PR DESCRIPTION
Per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/