### PR TITLE
Fix sync-dev-to-master workflow skipping all runs

### DIFF
--- a/.github/workflows/sync-dev-to-master.yaml
+++ b/.github/workflows/sync-dev-to-master.yaml
@@ -9,7 +9,7 @@ jobs:
   sync:
     name: Fast-forward dev to master
     runs-on: ubuntu-latest
-    if: startsWith(github.event.head_commit.message, 'Merge pull request') && endsWith(github.event.head_commit.message, '/dev')
+    if: contains(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, 'from fragforce/dev')
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The `endsWith` condition on the sync workflow always evaluated false because GitHub merge commit messages are multi-line — the message ends with the PR title body, not `/dev`. Replaced with `contains` so the match works against any part of the full message.

**Before:**
```yaml
if: startsWith(..., 'Merge pull request') && endsWith(..., '/dev')
```

**After:**
```yaml
if: contains(..., 'Merge pull request') && contains(..., 'from fragforce/dev')
```

## Test Results

## Test Run - `all` @ `54bc0e6`

**:white_check_mark: Ran 178 tests in 0.576s** - 2026-04-02

```
Ran 178 tests in 0.576s

OK
```