### PR TITLE
Fix legacy ENV key/value format in Dockerfiles

### DIFF
--- a/Dockerfile.beat
+++ b/Dockerfile.beat
@@ -1,10 +1,10 @@
 FROM python:3.10-slim as base
 
 # Setup env
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONFAULTHANDLER 1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONFAULTHANDLER=1
 RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev
 
 FROM base AS python-deps

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,10 +1,10 @@
 FROM python:3.10-slim as base
 
 # Setup env
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONFAULTHANDLER 1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONFAULTHANDLER=1
 RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev
 
 FROM base AS python-deps

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,10 +1,10 @@
 FROM python:3.10-slim as base
 
 # Setup env
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONFAULTHANDLER 1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONFAULTHANDLER=1
 RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev
 
 FROM base AS python-deps


### PR DESCRIPTION
## Summary

- Updates `Dockerfile.web`, `Dockerfile.beat`, and `Dockerfile.worker` to use `ENV key=value` format instead of the legacy `ENV key value` whitespace-separated format

## Test plan

- [x] 186 tests passed

```
Ran 186 tests in 0.718s

OK
```