### PR TITLE
Fix FROM/AS casing mismatch in Dockerfiles

### DIFF
--- a/Dockerfile.beat
+++ b/Dockerfile.beat
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.10-slim AS base
 
 # Setup env
 ENV LANG=C.UTF-8

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.10-slim AS base
 
 # Setup env
 ENV LANG=C.UTF-8

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.10-slim AS base
 
 # Setup env
 ENV LANG=C.UTF-8


### PR DESCRIPTION
## Summary

- Updates `Dockerfile.web`, `Dockerfile.beat`, and `Dockerfile.worker` to use uppercase `AS` to match the uppercase `FROM` keyword

## Test plan

- [x] 186 tests passed

```
Ran 186 tests in 0.659s

OK
```