### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -20,7 +20,7 @@ jobs:
         dockerfile: [ "web", "worker", "beat" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           lfs: true
       - name: Debug
@@ -28,13 +28,13 @@ jobs:
           echo "github.ref -> {{ github.ref }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
           buildkitd-flags: --debug
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMG_NAME }}-${{ matrix.dockerfile }}
           tags: |
@@ -45,14 +45,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           file: Dockerfile.${{ matrix.dockerfile }}

--- a/.github/workflows/prod-images.yaml
+++ b/.github/workflows/prod-images.yaml
@@ -22,7 +22,7 @@ jobs:
         dockerfile: [ "web", "worker", "beat" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           lfs: true
       - name: Debug
@@ -30,13 +30,13 @@ jobs:
           echo "github.ref -> {{ github.ref }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
           buildkitd-flags: --debug
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMG_NAME }}-${{ matrix.dockerfile }}
           tags: |
@@ -47,14 +47,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           file: Dockerfile.${{ matrix.dockerfile }}


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions in `dev-images.yaml` and `prod-images.yaml` to full commit SHAs instead of floating version tags to prevent supply chain attacks via tag mutation
- Version tags retained as comments for readability

## Test plan

- [x] 186 tests passed

```
Ran 186 tests in 0.551s

OK
```

## SonarCloud Analysis

https://sonarcloud.io/dashboard?id=fragforce_fragforce.org&pullRequest=864