### PR TITLE
Fix key regeneration FK constraint error when stream history exists

### DIFF
--- a/ffstream/admin.py
+++ b/ffstream/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
+from django.db import connection, transaction
 
 from .models import Key, Stream
 from .wordlist import generate_stream_key
@@ -88,7 +89,12 @@ class KeyAdmin(admin.ModelAdmin):
             candidate = generate_stream_key()
             while Key.objects.filter(id=candidate).exists():
                 candidate = generate_stream_key()
-            Key.objects.filter(pk=key.pk).update(id=candidate)
+            with transaction.atomic():
+                with connection.cursor() as cursor:
+                    cursor.execute("SET CONSTRAINTS ALL DEFERRED")
+                old_id = key.pk
+                Key.objects.filter(pk=old_id).update(id=candidate)
+                Stream.objects.filter(key_id=old_id).update(key_id=candidate)
 
     actions = ['regenerate_key']
 

--- a/ffstream/views.py
+++ b/ffstream/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required
+from django.db import connection, transaction
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.shortcuts import render
@@ -164,7 +165,14 @@ def regenerate_key(request):
     candidate = generate_stream_key()
     while Key.objects.filter(id=candidate).exists():
         candidate = generate_stream_key()
-    Key.objects.filter(owner=request.user).update(id=candidate)
+    with transaction.atomic():
+        with connection.cursor() as cursor:
+            cursor.execute("SET CONSTRAINTS ALL DEFERRED")
+        old_key = Key.objects.filter(owner=request.user).first()
+        if old_key:
+            old_id = old_key.pk
+            Key.objects.filter(pk=old_id).update(id=candidate)
+            Stream.objects.filter(key_id=old_id).update(key_id=candidate)
     return redirect('my-keys')
 
 


### PR DESCRIPTION
Fixes IntegrityError when regenerating a stream key that has historical Stream records. Uses deferred FK constraints within a transaction to update both the Key id and all referencing Stream records atomically.

---

## Test Results

## Test Run - `all` @ `316128c`

**:white_check_mark: Ran 231 tests in 10.776s** - 2026-04-09

```
Ran 231 tests in 10.776s

OK
```