### PR TITLE
Fix generate_key name collision for users with pre-existing keys

### DIFF
--- a/ffstream/tests.py
+++ b/ffstream/tests.py
@@ -108,6 +108,24 @@ class GenerateKeyViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn('/auth/login/discord/', response['Location'])
 
+    def test_claims_existing_unowned_key_with_matching_name(self):
+        # Pre-existing key with the user's username but no owner (legacy data)
+        existing = Key.objects.create(name='streamer', id='OldLegacyKeyValue')
+        self.client.login(username='streamer', password=TEST_PASSWORD)
+        self.client.post(reverse('generate-key'))
+        existing.refresh_from_db()
+        self.assertEqual(existing.owner, self.user)
+        self.assertEqual(Key.objects.filter(owner=self.user).count(), 1)
+
+    def test_avoids_name_collision_with_owned_key(self):
+        # Key with user's username already owned by someone else
+        other = User.objects.create_user(username='other', password=TEST_PASSWORD)
+        Key.objects.create(name='streamer', owner=other)
+        self.client.login(username='streamer', password=TEST_PASSWORD)
+        self.client.post(reverse('generate-key'))
+        key = Key.objects.get(owner=self.user)
+        self.assertNotEqual(key.name, 'streamer')
+
 
 class RegenerateKeyViewTest(TestCase):
     def setUp(self):

--- a/ffstream/views.py
+++ b/ffstream/views.py
@@ -150,12 +150,22 @@ def my_keys(request):
 @login_required
 def generate_key(request):
     if not Key.objects.filter(owner=request.user).exists():
-        Key.objects.create(
-            name=request.user.username,
-            owner=request.user,
-            superstream=False,
-            livestream=False,
-        )
+        # Claim an existing unowned key with the user's name if one exists
+        claimed = Key.objects.filter(name=request.user.username, owner=None).first()
+        if claimed:
+            claimed.owner = request.user
+            claimed.save()
+        else:
+            name = request.user.username
+            # Avoid name collision with a key owned by someone else
+            while Key.objects.filter(name=name).exists():
+                name = f"{request.user.username}-{generate_stream_key()[:8]}"
+            Key.objects.create(
+                name=name,
+                owner=request.user,
+                superstream=False,
+                livestream=False,
+            )
     return redirect('my-keys')
 
 


### PR DESCRIPTION
Fixes a production IntegrityError when a user tries to generate a stream key but a Key with their username already exists without an owner (legacy manually-created keys from before the owner field was added).

If an unowned Key with the user's username exists, claim it rather than creating a duplicate. If a Key with that name belongs to someone else, generate a unique name to avoid the collision. Tests added for both scenarios.