### PR TITLE
Restrict dev/prod image builds to upstream repo and fail fast if Docker not running

### DIFF
--- a/.github/workflows/dev-images.yaml
+++ b/.github/workflows/dev-images.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     name: Build & push docker image
+    if: github.repository == 'fragforce/fragforce.org'
     runs-on: ubuntu-latest
     env:
       IMG_NAME: fragforce-dev

--- a/.github/workflows/prod-images.yaml
+++ b/.github/workflows/prod-images.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     name: Build & push docker image
+    if: github.repository == 'fragforce/fragforce.org'
     runs-on: ubuntu-latest
     env:
       IMG_NAME: fragforce-prod

--- a/dev/runtests.sh
+++ b/dev/runtests.sh
@@ -8,6 +8,12 @@
 
 cd "$(git rev-parse --show-toplevel)"
 
+# Check Docker daemon is available before proceeding
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker daemon is not running or not accessible." >&2
+    exit 1
+fi
+
 # Ensure containers are running
 if ! docker compose ps -q --status running web 2>/dev/null | grep -q .; then
     echo "Containers not running - starting dev stack..."


### PR DESCRIPTION
## Summary

- Add `if: github.repository == 'fragforce/fragforce.org'` to dev-images.yaml and prod-images.yaml so build jobs are silently skipped in forks
- Add Docker daemon availability check to dev/runtests.sh that fails immediately with a clear error instead of waiting for the 5 minute timeout