### PR TITLE
Discord credential validation, expanded tests, and SonarCloud coverage

### DIFF
--- a/ffbot/management/commands/run_discord_bot.py
+++ b/ffbot/management/commands/run_discord_bot.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand
 
 from ffbot.utils import get_or_create_stream_key, get_or_register_user
 from ffdiscord.utils import sync_user_roles
+from ffdiscord.validators import discord_bot_token_valid
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +16,9 @@ class Command(BaseCommand):
     help = 'Run the Fragforce Discord bot'
 
     def handle(self, *args, **options):
+        if not discord_bot_token_valid(settings.DISCORD_BOT_TOKEN):
+            raise SystemExit("DISCORD_BOT_TOKEN is missing or invalid - bot cannot start.")
+
         intents = discord.Intents.default()
         bot = discord.Bot(intents=intents)
 

--- a/ffbot/tests.py
+++ b/ffbot/tests.py
@@ -1,0 +1,90 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from evtsignup.models import DiscordEventUser
+from ffbot.utils import get_or_create_stream_key, get_or_register_user
+from ffstream.models import Key
+from social_django.models import UserSocialAuth
+
+
+class GetOrRegisterUserTest(TestCase):
+    def test_returns_existing_user_via_discord_event_user(self):
+        user = User.objects.create_user(username='existing')
+        DiscordEventUser.objects.create(user=user, discord_id='111111111111111111')
+        result = get_or_register_user('111111111111111111', 'existing')
+        self.assertEqual(result, user)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_returns_existing_user_via_social_auth(self):
+        user = User.objects.create_user(username='webuser')
+        UserSocialAuth.objects.create(user=user, provider='discord', uid='222222222222222222', extra_data={})
+        result = get_or_register_user('222222222222222222', 'webuser')
+        self.assertEqual(result, user)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_creates_new_user_with_correct_records(self):
+        result = get_or_register_user('333333333333333333', 'newuser')
+        self.assertEqual(result.username, 'newuser')
+        self.assertTrue(DiscordEventUser.objects.filter(user=result, discord_id='333333333333333333').exists())
+        self.assertTrue(UserSocialAuth.objects.filter(user=result, provider='discord', uid='333333333333333333').exists())
+
+    def test_handles_username_collision(self):
+        User.objects.create_user(username='streamer')
+        result = get_or_register_user('444444444444444444', 'streamer')
+        self.assertNotEqual(result.username, 'streamer')
+        self.assertIn('streamer', result.username)
+
+    def test_slugifies_username_with_periods(self):
+        result = get_or_register_user('555555555555555555', 'aevum.decessus')
+        self.assertEqual(result.username, 'aevum-decessus')
+
+    def test_creates_user_with_empty_email(self):
+        result = get_or_register_user('666666666666666666', 'nomail')
+        self.assertEqual(result.email, '')
+
+
+class GetOrCreateStreamKeyTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='streamer')
+
+    def test_returns_existing_key(self):
+        key = Key.objects.create(name='streamer', owner=self.user)
+        result = get_or_create_stream_key(self.user)
+        self.assertEqual(result.pk, key.pk)
+        self.assertEqual(Key.objects.filter(owner=self.user).count(), 1)
+
+    def test_creates_new_key_for_user(self):
+        result = get_or_create_stream_key(self.user)
+        self.assertEqual(result.owner, self.user)
+
+    def test_new_key_has_superstream_false(self):
+        result = get_or_create_stream_key(self.user)
+        self.assertFalse(result.superstream)
+
+    def test_new_key_has_livestream_false(self):
+        result = get_or_create_stream_key(self.user)
+        self.assertFalse(result.livestream)
+
+    def test_handles_name_collision(self):
+        other = User.objects.create_user(username='other')
+        Key.objects.create(name='streamer', owner=other)
+        result = get_or_create_stream_key(self.user)
+        self.assertNotEqual(result.name, 'streamer')
+        self.assertEqual(result.owner, self.user)
+
+    def test_handles_stream_key_collision(self):
+        from unittest.mock import patch
+        from ffstream.wordlist import generate_stream_key as real_gen
+        existing = Key.objects.create(name='collision', stream_key='CollisionKey')
+        call_count = {'n': 0}
+
+        def patched():
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                return existing.stream_key
+            return real_gen()
+
+        with patch('ffbot.utils.generate_stream_key', patched):
+            result = get_or_create_stream_key(self.user)
+        self.assertNotEqual(result.stream_key, existing.stream_key)
+        self.assertGreaterEqual(call_count['n'], 2)

--- a/ffdiscord/tests.py
+++ b/ffdiscord/tests.py
@@ -1,5 +1,8 @@
+from django.contrib.auth.models import Group, User
 from django.test import TestCase
 
+from ffdiscord.models import DiscordRole, DiscordRoleMapping
+from ffdiscord.utils import sync_guild_roles, sync_user_roles
 from ffdiscord.validators import (
     discord_bot_token_valid,
     discord_oauth_credentials_valid,
@@ -75,3 +78,76 @@ class DiscordBotTokenValidTest(TestCase):
 
     def test_missing_dots(self):
         self.assertFalse(discord_bot_token_valid('M' + 'A' * 70))
+
+
+class SyncGuildRolesTest(TestCase):
+    def test_creates_new_roles(self):
+        sync_guild_roles([('111', 'Admin'), ('222', 'Streamer')])
+        self.assertEqual(DiscordRole.objects.count(), 2)
+        self.assertTrue(DiscordRole.objects.filter(discord_role_id='111', name='Admin').exists())
+
+    def test_updates_existing_role_name(self):
+        DiscordRole.objects.create(discord_role_id='111', name='OldName')
+        sync_guild_roles([('111', 'NewName')])
+        self.assertEqual(DiscordRole.objects.get(discord_role_id='111').name, 'NewName')
+
+    def test_handles_empty_list(self):
+        sync_guild_roles([])
+        self.assertEqual(DiscordRole.objects.count(), 0)
+
+    def test_upserts_multiple_roles(self):
+        DiscordRole.objects.create(discord_role_id='111', name='Existing')
+        sync_guild_roles([('111', 'Updated'), ('222', 'New')])
+        self.assertEqual(DiscordRole.objects.count(), 2)
+        self.assertEqual(DiscordRole.objects.get(discord_role_id='111').name, 'Updated')
+
+
+class SyncUserRolesTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='streamer')
+        self.role = DiscordRole.objects.create(discord_role_id='111', name='Streamer')
+        self.group = Group.objects.create(name='streamers')
+        self.mapping = DiscordRoleMapping.objects.create(role=self.role, group=self.group)
+
+    def test_adds_entitled_group(self):
+        sync_user_roles(self.user, ['111'])
+        self.assertIn(self.group, self.user.groups.all())
+
+    def test_removes_unentitled_group(self):
+        self.user.groups.add(self.group)
+        sync_user_roles(self.user, [])
+        self.assertNotIn(self.group, self.user.groups.all())
+
+    def test_no_change_when_correct(self):
+        self.user.groups.add(self.group)
+        sync_user_roles(self.user, ['111'])
+        self.assertIn(self.group, self.user.groups.all())
+
+    def test_early_return_when_no_mappings(self):
+        DiscordRoleMapping.objects.all().delete()
+        self.user.groups.add(self.group)
+        sync_user_roles(self.user, [])
+        # Should not remove group since there are no mappings to manage
+        self.assertIn(self.group, self.user.groups.all())
+
+    def test_grants_staff_access(self):
+        self.mapping.grants_staff_access = True
+        self.mapping.save()
+        sync_user_roles(self.user, ['111'])
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_staff)
+
+    def test_revokes_staff_access(self):
+        self.mapping.grants_staff_access = True
+        self.mapping.save()
+        self.user.is_staff = True
+        self.user.save()
+        self.user.groups.add(self.group)
+        sync_user_roles(self.user, [])
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_staff)
+
+    def test_staff_not_set_without_grants_staff_access(self):
+        sync_user_roles(self.user, ['111'])
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_staff)

--- a/ffdiscord/tests.py
+++ b/ffdiscord/tests.py
@@ -1,0 +1,77 @@
+from django.test import TestCase
+
+from ffdiscord.validators import (
+    discord_bot_token_valid,
+    discord_oauth_credentials_valid,
+)
+
+VALID_CLIENT_ID = '123456789012345678'  # 18-digit snowflake  # NOSONAR
+VALID_CLIENT_SECRET = 'abcDEF123_-abcDEF123_-abcDEF1234'  # 32 chars  # NOSONAR
+VALID_BOT_TOKEN = 'MTestToken1234567890123456.AAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'  # NOSONAR
+
+
+class DiscordOAuthCredentialsValidTest(TestCase):
+    def test_valid_credentials(self):
+        self.assertTrue(discord_oauth_credentials_valid(VALID_CLIENT_ID, VALID_CLIENT_SECRET))
+
+    def test_empty_client_id(self):
+        self.assertFalse(discord_oauth_credentials_valid('', VALID_CLIENT_SECRET))
+
+    def test_none_client_id(self):
+        self.assertFalse(discord_oauth_credentials_valid(None, VALID_CLIENT_SECRET))
+
+    def test_non_numeric_client_id(self):
+        self.assertFalse(discord_oauth_credentials_valid('abc123abc123abc123', VALID_CLIENT_SECRET))
+
+    def test_client_id_too_short(self):
+        self.assertFalse(discord_oauth_credentials_valid('1234567890123456', VALID_CLIENT_SECRET))
+
+    def test_client_id_too_long(self):
+        self.assertFalse(discord_oauth_credentials_valid('123456789012345678901', VALID_CLIENT_SECRET))
+
+    def test_empty_client_secret(self):
+        self.assertFalse(discord_oauth_credentials_valid(VALID_CLIENT_ID, ''))
+
+    def test_none_client_secret(self):
+        self.assertFalse(discord_oauth_credentials_valid(VALID_CLIENT_ID, None))
+
+    def test_client_secret_wrong_length(self):
+        self.assertFalse(discord_oauth_credentials_valid(VALID_CLIENT_ID, 'tooshort'))
+
+    def test_client_secret_invalid_chars(self):
+        self.assertFalse(discord_oauth_credentials_valid(VALID_CLIENT_ID, 'abcDEF123!@abcDEF123!@abcDEF12'))
+
+
+class DiscordBotTokenValidTest(TestCase):
+    def test_valid_token_starts_with_M(self):
+        token = 'M' + 'A' * 25 + '.' + 'B' * 6 + '.' + 'C' * 38
+        self.assertTrue(discord_bot_token_valid(token))
+
+    def test_valid_token_starts_with_N(self):
+        token = 'N' + 'A' * 25 + '.' + 'B' * 6 + '.' + 'C' * 38
+        self.assertTrue(discord_bot_token_valid(token))
+
+    def test_empty_token(self):
+        self.assertFalse(discord_bot_token_valid(''))
+
+    def test_none_token(self):
+        self.assertFalse(discord_bot_token_valid(None))
+
+    def test_wrong_starting_char(self):
+        token = 'X' + 'A' * 25 + '.' + 'B' * 6 + '.' + 'C' * 38
+        self.assertFalse(discord_bot_token_valid(token))
+
+    def test_wrong_part1_length(self):
+        token = 'M' + 'A' * 24 + '.' + 'B' * 6 + '.' + 'C' * 38
+        self.assertFalse(discord_bot_token_valid(token))
+
+    def test_wrong_part2_length(self):
+        token = 'M' + 'A' * 25 + '.' + 'B' * 5 + '.' + 'C' * 38
+        self.assertFalse(discord_bot_token_valid(token))
+
+    def test_wrong_part3_length(self):
+        token = 'M' + 'A' * 25 + '.' + 'B' * 6 + '.' + 'C' * 37
+        self.assertFalse(discord_bot_token_valid(token))
+
+    def test_missing_dots(self):
+        self.assertFalse(discord_bot_token_valid('M' + 'A' * 70))

--- a/ffdiscord/validators.py
+++ b/ffdiscord/validators.py
@@ -1,0 +1,21 @@
+import re
+
+# Discord client ID is a snowflake: decimal digits, 17-20 chars
+DISCORD_CLIENT_ID_RE = re.compile(r'^\d{17,20}$')
+
+# Discord client secret: 32 chars, lowercase, uppercase, digits, underscore, dash
+DISCORD_CLIENT_SECRET_RE = re.compile(r'^[a-zA-Z0-9_-]{32}$')
+
+# Discord bot token: MN + 25 chars . 6 chars . 38 chars
+DISCORD_BOT_TOKEN_RE = re.compile(r'^[MN][A-Za-z0-9]{25}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{38}$')
+
+
+def discord_oauth_credentials_valid(client_id: str, client_secret: str) -> bool:
+    return bool(
+        DISCORD_CLIENT_ID_RE.match(client_id or '') and
+        DISCORD_CLIENT_SECRET_RE.match(client_secret or '')
+    )
+
+
+def discord_bot_token_valid(token: str) -> bool:
+    return bool(DISCORD_BOT_TOKEN_RE.match(token or ''))

--- a/ffsite/ctx.py
+++ b/ffsite/ctx.py
@@ -2,9 +2,16 @@ import datetime
 
 from django.conf import settings
 
+from ffdiscord.validators import discord_oauth_credentials_valid
+
+
 def common_org(request):
     """ Context processors for all ffsite pages """
     return dict(
         now=datetime.datetime.utcnow(),
         gaid=settings.GOOGLE_ANALYTICS_ID,
+        discord_login_enabled=discord_oauth_credentials_valid(
+            settings.SOCIAL_AUTH_DISCORD_KEY,
+            settings.SOCIAL_AUTH_DISCORD_SECRET,
+        ),
     )

--- a/ffsite/templates/ff/base.html
+++ b/ffsite/templates/ff/base.html
@@ -76,9 +76,11 @@
                     </form>
                 </li>
                 {% else %}
+                {% if discord_login_enabled %}
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'social:begin' 'discord' %}">Login</a>
                 </li>
+                {% endif %}
                 {% endif %}
             </ul>
             <ul class="navbar-nav navbar-right">

--- a/ffsite/tests.py
+++ b/ffsite/tests.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 
@@ -10,3 +10,22 @@ class LoginErrorViewTest(TestCase):
     def test_contains_discord_invite_link(self):
         response = self.client.get(reverse('login-error'))
         self.assertContains(response, 'discord.gg/fragforce')
+
+
+class DiscordLoginButtonTest(TestCase):
+    def setUp(self):
+        from django.core.cache import cache
+        cache.clear()
+
+    @override_settings(
+        SOCIAL_AUTH_DISCORD_KEY='123456789012345678',
+        SOCIAL_AUTH_DISCORD_SECRET='abcDEF123_-abcDEF123_-abcDEF1234',
+    )
+    def test_login_button_shown_when_credentials_valid(self):
+        response = self.client.get(reverse('home'))
+        self.assertContains(response, reverse('social:begin', args=['discord']))
+
+    @override_settings(SOCIAL_AUTH_DISCORD_KEY='', SOCIAL_AUTH_DISCORD_SECRET='')
+    def test_login_button_hidden_when_credentials_empty(self):
+        response = self.client.get(reverse('home'))
+        self.assertNotContains(response, reverse('social:begin', args=['discord']))


### PR DESCRIPTION
## Summary

Discord credential validation, expanded test coverage, and SonarCloud coverage reporting.

## Changes

### Discord Credential Validation (`ffdiscord/validators.py`)
New module with regex validators for all Discord credential types:
- `DISCORD_CLIENT_ID` - snowflake format, 17-20 decimal digits
- `DISCORD_CLIENT_SECRET` - 32 chars, alphanumeric + underscore + dash (observed from all environments)
- `DISCORD_BOT_TOKEN` - `[MN]{26}.{6}.{38}` format (observed from all environments)

`discord_oauth_credentials_valid()` is used by the navbar context processor to hide the Login button when credentials are missing or invalid. `discord_bot_token_valid()` is used by `run_discord_bot` to fail fast on startup with a clear error instead of an obscure Discord API error.

The 5-minute page cache means a credential change requires a server restart to take effect immediately - this is acceptable since env var changes require a restart anyway.

### Test Coverage (high priority gaps)

**`ffbot/tests.py`** (new):
- `get_or_register_user` - all three lookup paths (DiscordEventUser, UserSocialAuth, new user), username collision handling, period-to-hyphen slugification, empty email
- `get_or_create_stream_key` - existing key returned, new key creation, name collision, stream key collision, superstream/livestream defaults

**`ffdiscord/tests.py`** (expanded):
- `sync_guild_roles` - create, update, empty list, bulk upsert
- `sync_user_roles` - add/remove groups, early return when no mappings, staff grant/revoke, no change when already correct

**`ffdiscord/tests.py`** (existing, expanded):
- Discord credential validators - all valid/invalid cases for client ID, secret, and bot token

**`ffsite/tests.py`** (expanded):
- Login button shown/hidden based on credential validity, with cache cleared before each test

### SonarCloud Coverage Reporting

New `.github/workflows/coverage.yaml`:
- Runs on push to `dev`/`master` and all PRs
- Restricted to `fragforce/fragforce.org` only (won't run in forks)
- Starts postgres 18.3 and redis as services
- Runs `coverage run manage.py test` then `coverage xml`
- Uploads to SonarCloud via `SonarSource/sonarcloud-github-action@v5`
- Requires `SONAR_TOKEN` secret set in repo settings

`sonar-project.properties` updated with `sonar.python.coverage.reportPaths` and `sonar.python.version`.

`coverage` added to `[dev-packages]` in Pipfile.

## Test plan

- [x] 279 tests passing locally
