### PR TITLE
Fix CI workflows: sonarqube-scan-action v7 and GitHub App token for test reporter

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -44,14 +44,14 @@ jobs:
 
       - name: SonarCloud Scan (push)
         if: github.event.workflow_run.event != 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarCloud Scan (pull request)
         if: github.event.workflow_run.event == 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -18,6 +18,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate app token
+        id: app-token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        with:
+          app_id: ${{ secrets.FRAGFORCE_CI_APP_ID }}
+          private_key: ${{ secrets.FRAGFORCE_CI_PRIVATE_KEY }}
+
       - name: Download coverage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -32,6 +39,7 @@ jobs:
           path: TEST-*.xml
           reporter: java-junit
           fail-on-error: false
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set PR properties for SonarCloud
         if: github.event.workflow_run.event == 'pull_request'


### PR DESCRIPTION
## Summary

Two fixes to the SonarCloud/coverage CI workflows:

### Update sonarqube-scan-action to v7 (Node.js 24)
The v6 action was running on Node.js 20 which is deprecated and will be removed September 2026. Updated to v7 which uses Node.js 24.

### Use GitHub App token for dorny/test-reporter
The test reporter was silently failing to create check runs on PRs because `GITHUB_TOKEN` in a `workflow_run` context cannot create check runs on the PR's check suite. Using the `FRAGFORCE_CI` GitHub App (org-level secrets `FRAGFORCE_CI_APP_ID` and `FRAGFORCE_CI_PRIVATE_KEY`) which has `checks: write` permission resolves this. The Django Tests check run will now correctly appear on PRs.