### PR TITLE
Fix Django Tests check runs on PRs

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -39,6 +39,7 @@ jobs:
           path: TEST-*.xml
           reporter: java-junit
           fail-on-error: false
+          use-actions-summary: false
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set PR properties for SonarCloud

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -20,10 +20,10 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
-          app_id: ${{ secrets.FRAGFORCE_CI_APP_ID }}
-          private_key: ${{ secrets.FRAGFORCE_CI_PRIVATE_KEY }}
+          app-id: ${{ secrets.FRAGFORCE_CI_APP_ID }}
+          private-key: ${{ secrets.FRAGFORCE_CI_PRIVATE_KEY }}
 
       - name: Download coverage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/sync-dev-to-master.yaml
+++ b/.github/workflows/sync-dev-to-master.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
-          app_id: ${{ secrets.FRAGFORCE_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.FRAGFORCE_AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.FRAGFORCE_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.FRAGFORCE_AUTOMATION_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Two fixes to get the Django Tests check run appearing on PRs:

### Fix: `use-actions-summary: false` in dorny/test-reporter
`dorny/test-reporter@v3` defaults `use-actions-summary` to `true`, which writes results to the job summary instead of creating a GitHub Check Run. Setting it to `false` forces use of the Checks API with the app token.

### Fix: Replace tibdex/github-app-token with actions/create-github-app-token
`tibdex/github-app-token` hasn't been updated since 2023 and uses node16 (deprecated). Replaced with the official GitHub-maintained `actions/create-github-app-token@v3.1.1` (node24) in both `sonar.yaml` and `sync-dev-to-master.yaml`.