### PR TITLE
Fix SonarCloud PR analysis: correct checkout, base branch, and branch name

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -63,10 +63,11 @@ jobs:
           pipenv run coverage xml
 
       - name: Save PR metadata
-        if: github.event_name == 'pull_request'
         run: |
-          echo "${{ github.event.number }}" > pr_number.txt
+          echo "${{ github.event_name == 'pull_request' && github.event.number || '' }}" > pr_number.txt
           echo "${{ github.sha }}" > pr_sha.txt
+          echo "${{ github.base_ref }}" > pr_base_ref.txt
+          echo "${{ github.ref_name }}" > branch_name.txt
 
       - name: Upload coverage and test artifacts
         if: success()
@@ -78,4 +79,6 @@ jobs:
             TEST-*.xml
             pr_number.txt
             pr_sha.txt
+            pr_base_ref.txt
+            branch_name.txt
           retention-days: 1

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout PR code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Generate app token
@@ -42,14 +43,15 @@ jobs:
           use-actions-summary: false
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Set PR properties for SonarCloud
-        if: github.event.workflow_run.event == 'pull_request'
+      - name: Set scan properties
         env:
           PR_NUMBER_FILE: pr_number.txt
-          PR_SHA_FILE: pr_sha.txt
+          PR_BASE_REF_FILE: pr_base_ref.txt
+          BRANCH_NAME_FILE: branch_name.txt
         run: |
           echo "SONAR_PR_NUMBER=$(cat "$PR_NUMBER_FILE")" >> "$GITHUB_ENV"
-          echo "SONAR_PR_SHA=$(cat "$PR_SHA_FILE")" >> "$GITHUB_ENV"
+          echo "SONAR_PR_BASE=$(cat "$PR_BASE_REF_FILE")" >> "$GITHUB_ENV"
+          echo "SONAR_BRANCH_NAME=$(cat "$BRANCH_NAME_FILE")" >> "$GITHUB_ENV"
 
       - name: SonarCloud Scan (push)
         if: github.event.workflow_run.event != 'pull_request'
@@ -57,6 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_SCANNER_OPTS: -Dsonar.branch.name=${{ env.SONAR_BRANCH_NAME }}
 
       - name: SonarCloud Scan (pull request)
         if: github.event.workflow_run.event == 'pull_request'
@@ -67,4 +70,4 @@ jobs:
           SONAR_SCANNER_OPTS: >-
             -Dsonar.pullrequest.key=${{ env.SONAR_PR_NUMBER }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
-            -Dsonar.pullrequest.base=${{ github.base_ref }}
+            -Dsonar.pullrequest.base=${{ env.SONAR_PR_BASE }}


### PR DESCRIPTION
## Summary

Fixes two issues causing SonarCloud to report 0% coverage and not create a PR check:

### Fix: Checkout PR's head SHA instead of dev
The sonar workflow was checking out `dev` while `coverage.xml` was generated on the PR branch. Line numbers didn't match, causing `WARN: Cannot read coverage report ... Line 15 is out of range` and 0% coverage. Now checks out `github.event.workflow_run.head_sha`.

### Fix: Pass correct base branch to SonarCloud
`github.base_ref` is empty in `workflow_run` context, so `sonar.pullrequest.base` was empty causing SonarCloud to run a branch analysis instead of a PR analysis (no PR check created). Now stored in `pr_base_ref.txt` in the coverage artifact and read in the sonar workflow.

### Fix: Pass branch name for push scans
Checking out a detached HEAD at `head_sha` means git doesn't know the branch name. Passing `sonar.branch.name` explicitly for push scans ensures correct branch identification in SonarCloud.

### Fix: Always create metadata files
Metadata files are now always created (empty for push events) to avoid `upload-artifact` warnings about missing files.