### PR TITLE
Use app token as GITHUB_TOKEN for SonarCloud quality gate check run

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -57,7 +57,7 @@ jobs:
         if: github.event.workflow_run.event != 'pull_request'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_SCANNER_OPTS: -Dsonar.branch.name=${{ env.SONAR_BRANCH_NAME }}
 
@@ -65,7 +65,7 @@ jobs:
         if: github.event.workflow_run.event == 'pull_request'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_SCANNER_OPTS: >-
             -Dsonar.pullrequest.key=${{ env.SONAR_PR_NUMBER }}


### PR DESCRIPTION
## Summary

SonarCloud posts the Quality Gate result as a PR **comment** but not as a **Check Run** that can be set as required. The root cause is that `GITHUB_TOKEN` in `workflow_run` context lacks `checks: write` permission for fork PRs, so SonarCloud falls back to comment-only mode.

## Fix

Pass the GitHub App token (which has `checks: write`) as `GITHUB_TOKEN` to both SonarCloud scan steps. SonarCloud uses this token to create the Quality Gate check run on the PR.