### PR TITLE
Add sonar.qualitygate.wait and fix app-id deprecation

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -23,7 +23,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
-          app-id: ${{ secrets.FRAGFORCE_CI_APP_ID }}
+          client-id: ${{ secrets.FRAGFORCE_CI_APP_ID }}
           private-key: ${{ secrets.FRAGFORCE_CI_PRIVATE_KEY }}
 
       - name: Download coverage artifact

--- a/.github/workflows/sync-dev-to-master.yaml
+++ b/.github/workflows/sync-dev-to-master.yaml
@@ -15,7 +15,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
-          app-id: ${{ secrets.FRAGFORCE_AUTOMATION_APP_ID }}
+          client-id: ${{ secrets.FRAGFORCE_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.FRAGFORCE_AUTOMATION_PRIVATE_KEY }}
 
       - name: Checkout

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,6 @@ sonar.exclusions=dev/ffsfdc.sql,**/migrations/**
 # Coverage
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.10
+
+# Wait for quality gate result so the CI job reports pass/fail
+sonar.qualitygate.wait=true


### PR DESCRIPTION
## Summary

### Add `sonar.qualitygate.wait=true`
SonarCloud's async GitHub App check creation doesn't work for fork PRs (the commit SHA is from the fork, SonarCloud's App is only installed on the base repo). Setting `sonar.qualitygate.wait=true` makes the scanner itself poll SonarCloud for the quality gate result and fail the CI job if the gate fails. The **SonarCloud scan** job becomes the quality gate check on the PR - visible, settable as required, and doesn't depend on SonarCloud's async process.

### Fix `app-id` → `client-id` deprecation
`actions/create-github-app-token@v3` deprecated the `app-id` input in favour of `client-id`. Updated in both `sonar.yaml` and `sync-dev-to-master.yaml`.