### PR TITLE
Update aevum dev image workflow

### DIFF
--- a/.github/workflows/aevum-dev-images.yaml
+++ b/.github/workflows/aevum-dev-images.yaml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     branches:
-      - events
+      - '**'
 
 jobs:
   build:
@@ -38,7 +38,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMG_NAME }}-${{ matrix.dockerfile }}
           tags: |
-            type=raw,value=latest
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref_name == 'events' }}
             type=raw,value={{sha}},enable=${{ github.ref_type != 'tag' }}
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/aevum-dev-images.yaml
+++ b/.github/workflows/aevum-dev-images.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMG_NAME }}-${{ matrix.dockerfile }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest
             type=raw,value={{sha}},enable=${{ github.ref_type != 'tag' }}
 
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
## Summary

- Tags aevum dev images as `latest` (instead of branch name) so the deploy compose file has a stable tag to pull
- Builds images on all branch pushes (not just `events`), tagging with branch name + SHA; only `events` pushes also tag as `latest`

## Test plan

- [x] 235 tests passing locally