### PR TITLE
Fix SonarCloud major issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN pipenv install
 
 VOLUME /code
 
-CMD /bin/bash && wait
+CMD ["/bin/bash"]

--- a/Dockerfile.beat
+++ b/Dockerfile.beat
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
-RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev
+RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev && rm -rf /var/lib/apt/lists/*
 
 FROM base AS python-deps
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
-RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev
+RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev && rm -rf /var/lib/apt/lists/*
 
 FROM base AS python-deps
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
-RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev
+RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml python3-dev && rm -rf /var/lib/apt/lists/*
 
 FROM base AS python-deps
 

--- a/extralifeapi/base.py
+++ b/extralifeapi/base.py
@@ -41,7 +41,7 @@ class NotModifiedResponse:
 
 class DonorDriveBase(object):
     DEFAULT_BASE_URL = 'https://www.extra-life.org/api/'
-    RE_MATCH_LINK = re.compile(r'^\<(.*)\>;rel="(.*)"')
+    RE_MATCH_LINK = re.compile(r'^\<([^>]*)\>;rel="([^"]*)"')
 
     def __init__(self, base_url=DEFAULT_BASE_URL, log_parent=mod_logger, request_sleeper=None,
                  max_retries=None, server_max_retries=None, http_cache=None):

--- a/ffdonations/ctx.py
+++ b/ffdonations/ctx.py
@@ -3,10 +3,10 @@ from django.conf import settings
 from .utils import el_donation_stats, el_num_donations
 
 
-def donations(request):
+def donations(_request):
     """ Context processors for all ffdonations pages """
     ret = dict(
-        # FIXME: Add custom caching here - use tasks to pregenerate so it doesn't slow down random pages
+        # TODO: Add custom caching here - use tasks to pregenerate so it doesn't slow down random pages
         el_donation_stats=el_donation_stats(),
         el_num_donations=el_num_donations(),
     )

--- a/ffdonations/tasks/sender.py
+++ b/ffdonations/tasks/sender.py
@@ -9,12 +9,6 @@ from ..models import DonationModel
 TRACKING_BOT = 'TRACKING_BOT'
 
 
-# @receiver(post_save, sender=DonationModel)
-# def cb_post_save(sender, instance, **kwargs):
-#     if settings.FRAG_BOT_KEY != "":
-#         note_new_donation.delay(instance.id)
-
-
 @shared_task(bind=True)
 def note_new_donations(self):
     """ Check for missed donations """

--- a/ffdonations/tasks/teams.py
+++ b/ffdonations/tasks/teams.py
@@ -101,9 +101,8 @@ def update_teams(self, teams=None):
         tm.event = evt
 
         tm.raw = team.raw
-        if settings.EXTRALIFE_TEAMID >= 0:
-            if tm.id == settings.EXTRALIFE_TEAMID:
-                tm.tracked = True
+        if settings.EXTRALIFE_TEAMID >= 0 and tm.id == settings.EXTRALIFE_TEAMID:
+            tm.tracked = True
         tm.save()
 
         # Hook in donations update

--- a/ffdonations/urls.py
+++ b/ffdonations/urls.py
@@ -19,12 +19,12 @@ from ffdonations.views.donations import v_donations, v_tracked_donations
 from ffdonations.views.participants import v_participants, v_tracked_participants
 from ffdonations.views.stats import v_tracked_donations_stats
 from ffdonations.views.teams import v_teams, v_tracked_teams
-from ffdonations.views.testing import v_forceUpdate, v_testView
+from ffdonations.views.testing import v_force_update, v_test_view
 
 urlpatterns = [
     # Test stuff - Only enabled if DEBUG=True
-    path('test', v_testView, name='testview'),
-    path('update/force', v_forceUpdate, name='force-update'),
+    path('test', v_test_view, name='testview'),
+    path('update/force', v_force_update, name='force-update'),
     # Teams
     path('teams', v_teams, name='teams'),
     path('teams/tracked', v_tracked_teams, name='teams-tracked'),

--- a/ffdonations/utils.py
+++ b/ffdonations/utils.py
@@ -1,26 +1,9 @@
-# from .tasks import *
 from django.conf import settings
 from django.db.models import Sum
 from django.utils import timezone
 from memoize import memoize
 from .models import EventModel, TeamModel
 
-
-# @memoize(timeout=120)
-# def el_num_donations():
-#     baseq = DonationModel.objects.filter(DonationModel.tracked_q())
-#     return baseq.count()
-#
-#
-# @memoize(timeout=120)
-# def el_donation_stats():
-#     baseq = DonationModel.objects.filter(DonationModel.tracked_q())
-#     return baseq.aggregate(
-#         sumDonations=Sum('amount'),
-#         avgDonation=Avg('amount'),
-#         minDonation=Min('amount'),
-#         maxDonation=Max('amount'),
-#     )
 
 @memoize(timeout=120)
 def event_name_maker(year=timezone.now().year):
@@ -39,26 +22,6 @@ def el_teams(year=timezone.now().year):
     for tm in trackedTeams:
         ret.add(tm.id)
     return ret
-
-#
-# @memoize(timeout=120)
-# def el_contact(year=timezone.now().year):
-#     """ Returns a list of participant IDs that we're tracking for the given year """
-#     from ffdonations.tasks.participants import update_participants
-#     yr = event_name_maker(year=year)
-#     ret = []
-#     for sa in Contact.objects.filter(extra_life_id__isnull=False).only('extra_life_id').all():
-#         try:
-#             # Only query the api at all if we have MIN_EL_PARTICIPANTID set and our ID is >= it
-#             if settings.MIN_EL_PARTICIPANTID:
-#                 if int(sa.extra_life_id) >= settings.MIN_EL_PARTICIPANTID:
-#                     tm = ParticipantModel.objects.get(id=int(sa.extra_life_id))
-#                     if tm.event.name == yr:
-#                         ret.append(tm.id)
-#         except ParticipantModel.DoesNotExist:
-#             update_participants.delay([sa.extra_life_id, ])
-#     return ret
-#
 
 @memoize(timeout=120)
 def el_num_donations(year=timezone.now().year):

--- a/ffdonations/views/testing.py
+++ b/ffdonations/views/testing.py
@@ -27,7 +27,7 @@ def _onlydebug(f):
 
 @require_safe
 @_onlydebug
-def v_testView(request):
+def v_test_view(request):
     ret = [
         ('pct',),
         ('team',),
@@ -38,7 +38,7 @@ def v_testView(request):
 
 @require_safe
 @_onlydebug
-def v_forceUpdate(request):
+def v_force_update(request):
     ret = [
         update_donations_existing.delay(),
         update_participants.delay(),

--- a/fforg/celery.py
+++ b/fforg/celery.py
@@ -18,6 +18,3 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
 
-# @app.task(bind=True)
-# def test_task_512(self):
-#     print('Request: {0!r}'.format(self.request))

--- a/fforg/settings.py
+++ b/fforg/settings.py
@@ -107,7 +107,6 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
     },
 }
-# DATABASE_ROUTERS = ["fforg.router.HCRouter", ]
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',

--- a/ffsite/templates/ff/events/event.html
+++ b/ffsite/templates/ff/events/event.html
@@ -16,18 +16,14 @@
             {% if event.event_start_date %}
             <div class="event_info">
                 <strong>Start:</strong>
-                {% autoescape off %}
                 {{ event.event_start_date|localtime }}
-                {% endautoescape %}
             </div>
             {% endif %}
 
             {% if event.event_end_date %}
             <div class="event_info">
                 <strong>Ends:</strong>
-                {% autoescape off %}
                 {{ event.event_end_date|localtime }}
-                {% endautoescape %}
             </div>
             {% endif %}
 

--- a/ffsite/templates/ff/events/index.html
+++ b/ffsite/templates/ff/events/index.html
@@ -13,9 +13,7 @@
         <a href="{% url 'org_event' sfid=event.sfid %}"><h2>{{ event.name }}</h2></a>
         <div>
             <div>{{ event.site.name }}</div>
-            {% autoescape off %}
             <div>{{ event.event_start_date|localtime }} => {{ event.event_end_date|localtime }}</div>
-            {% endautoescape %}
             <div>
                 {% if event.description %}
                 {{ event.description }}

--- a/ffsite/templates/ff/events/upcoming.html
+++ b/ffsite/templates/ff/events/upcoming.html
@@ -13,9 +13,7 @@
         <a href="{% url 'org_event' sfid=event.sfid %}"><h2>{{ event.name }}</h2></a>
         <div>
             <div>{{ event.site.name }}</div>
-            {% autoescape off %}
             <div>{{ event.event_start_date|localtime }} => {{ event.event_end_date|localtime }}</div>
-            {% endautoescape %}
             <div>
                 {% if event.description %}
                 {{ event.description }}

--- a/ffstream/admin.py
+++ b/ffstream/admin.py
@@ -79,13 +79,13 @@ class KeyAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            return ('stream_key',)
-        return ()
+            return ['stream_key']
+        return []
 
     def get_exclude(self, request, obj=None):
         if not obj:
-            return ('stream_key',)
-        return ()
+            return ['stream_key']
+        return []
 
     @admin.action(description="Regenerate stream key")
     def regenerate_key(self, request, queryset):


### PR DESCRIPTION
Addresses SonarCloud major issues. S3776 (cognitive complexity), S6553 (null=True migrations), and S4084 (video subtitles) are excluded.

## Changes

- S6587: Clear apt cache after install in Dockerfiles; use exec form CMD in dev Dockerfile (S7019)
- S125: Remove commented-out dead code from utils.py, sender.py, celery.py, settings.py
- S8495: Return lists consistently from ffstream/admin.py get_readonly_fields/get_exclude
- S1066: Merge nested if in ffdonations/tasks/teams.py
- S1172/S1134: Rename unused request param to _request, change FIXME to TODO in ctx.py
- S1542: Rename v_testView/v_forceUpdate to snake_case in views/testing.py and urls.py
- Template cleanup: Remove unnecessary autoescape off from datetime-only blocks

## Test plan

- [x] 311 tests passing locally