### PR TITLE
Fix apt-get update missing in python-deps stage

### DIFF
--- a/Dockerfile.beat
+++ b/Dockerfile.beat
@@ -12,7 +12,7 @@ FROM base AS python-deps
 # Install pipenv and compilation dependencies
 RUN pip install --upgrade pip
 RUN pip install pipenv asdf
-RUN apt-get install -y --no-install-recommends gcc git
+RUN apt-get update && apt-get install -y --no-install-recommends gcc git && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies in /.venv
 COPY Pipfile .

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -12,7 +12,7 @@ FROM base AS python-deps
 # Install pipenv and compilation dependencies
 RUN pip install --upgrade pip
 RUN pip install pipenv asdf
-RUN apt-get install -y --no-install-recommends gcc git python3-dev
+RUN apt-get update && apt-get install -y --no-install-recommends gcc git python3-dev && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies in /.venv
 COPY Pipfile .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -12,7 +12,7 @@ FROM base AS python-deps
 # Install pipenv and compilation dependencies
 RUN pip install --upgrade pip
 RUN pip install pipenv asdf
-RUN apt-get install -y --no-install-recommends gcc git
+RUN apt-get update && apt-get install -y --no-install-recommends gcc git && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies in /.venv
 COPY Pipfile .


### PR DESCRIPTION
The S6587 fix added `rm -rf /var/lib/apt/lists/*` to the base stage, which cleared the package lists. The python-deps stage then failed trying to install gcc/git without a fresh `apt-get update`. Adds `apt-get update &&` before each install in the python-deps stage across all three Dockerfiles.