### PR TITLE
Fix donations() call site after request param rename

### DIFF
--- a/ffdonations/views/stats.py
+++ b/ffdonations/views/stats.py
@@ -9,4 +9,4 @@ from django.conf import settings
 @cache_page(settings.VIEW_DONATIONS_STATS_CACHE)
 def v_tracked_donations_stats(request):
     from ..ctx import donations
-    return JsonResponse(donations(request=request))
+    return JsonResponse(donations(request))


### PR DESCRIPTION
The S1172 fix renamed `request` to `_request` in `ffdonations/ctx.py`, but `stats.py` still called it as `donations(request=request)` which broke the keyword argument. Changed to positional call `donations(request)`.