### PR TITLE
Admin nav link and Discord login button for admin site

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -41,6 +41,7 @@ COPY evtsignup evtsignup
 COPY ffoverlay ffoverlay
 COPY ffbot ffbot
 COPY ffdiscord ffdiscord
+COPY templates templates
 COPY manage.py .
 
 RUN chown -R appuser /home/appuser

--- a/fforg/settings.py
+++ b/fforg/settings.py
@@ -79,7 +79,7 @@ ROOT_URLCONF = 'fforg.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/ffsite/templates/ff/base.html
+++ b/ffsite/templates/ff/base.html
@@ -69,6 +69,11 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'my-keys' %}">My Stream Keys</a>
                 </li>
+                {% if user.is_staff %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'admin:index' %}">Admin</a>
+                </li>
+                {% endif %}
                 <li class="nav-item">
                     <form method="post" action="{% url 'logout' %}" class="d-inline m-0 p-0">
                         {% csrf_token %}

--- a/ffsite/tests.py
+++ b/ffsite/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -148,3 +150,46 @@ class AdminLoginDiscordButtonTest(TestCase):
     def test_discord_button_preserves_next_param(self):
         response = self.client.get(reverse('admin:login') + '?next=/admin/ffstream/')
         self.assertContains(response, reverse('social:begin', args=['discord']) + '?next=/admin/ffstream/')
+
+
+class JoinAndContactViewTest(TestCase):
+    def test_join_returns_200(self):
+        response = self.client.get(reverse('join'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_contact_returns_200(self):
+        response = self.client.get(reverse('contact'))
+        self.assertEqual(response.status_code, 200)
+
+
+class LocaltimeFilterTest(TestCase):
+    def test_format_datetime_returns_html_with_value(self):
+        from ffsite.templatetags.fftz import format_datetime
+        result = format_datetime('2026-04-16T12:00:00')
+        self.assertIn('2026-04-16T12:00:00', result)
+        self.assertIn('<time', result)
+        self.assertIn('updateTimeValue', result)
+
+    def test_format_datetime_uses_provided_eid(self):
+        from ffsite.templatetags.fftz import format_datetime
+        result = format_datetime('2026-04-16T12:00:00', eid='myid')
+        self.assertIn('id="myid"', result)
+        self.assertIn('"#myid"', result)
+
+
+class RandomContactTest(TestCase):
+    @patch('ffsite.utils.el_teams', return_value=[1])
+    def test_returns_participant_when_exists(self, _):
+        from ffdonations.models import EventModel, TeamModel, ParticipantModel
+        event = EventModel.objects.create(id=1, name='Test', tracked=True)
+        team = TeamModel.objects.create(id=1, name='Team', tracked=True, event=event)
+        participant = ParticipantModel.objects.create(id=1, displayName='Alice', tracked=True, team=team, event=event)
+        from ffsite.utils import random_contact
+        result = random_contact()
+        self.assertEqual(result.id, participant.id)
+
+    @patch('ffsite.utils.el_teams', return_value=[])
+    def test_returns_empty_participant_when_none_exist(self, _):
+        from ffsite.utils import random_contact
+        result = random_contact()
+        self.assertIsInstance(result, __import__('ffdonations.models', fromlist=['ParticipantModel']).ParticipantModel)

--- a/ffsite/tests.py
+++ b/ffsite/tests.py
@@ -132,3 +132,19 @@ class AdminLoginDiscordButtonTest(TestCase):
     def test_discord_button_hidden_when_credentials_not_set(self):
         response = self.client.get(reverse('admin:login'))
         self.assertNotContains(response, reverse('social:begin', args=['discord']))
+
+    @override_settings(
+        SOCIAL_AUTH_DISCORD_KEY='123456789012345678',
+        SOCIAL_AUTH_DISCORD_SECRET='abcDEF123_-abcDEF123_-abcDEF1234',
+    )
+    def test_discord_button_includes_default_admin_next(self):
+        response = self.client.get(reverse('admin:login'))
+        self.assertContains(response, reverse('social:begin', args=['discord']) + '?next=/admin/')
+
+    @override_settings(
+        SOCIAL_AUTH_DISCORD_KEY='123456789012345678',
+        SOCIAL_AUTH_DISCORD_SECRET='abcDEF123_-abcDEF123_-abcDEF1234',
+    )
+    def test_discord_button_preserves_next_param(self):
+        response = self.client.get(reverse('admin:login') + '?next=/admin/ffstream/')
+        self.assertContains(response, reverse('social:begin', args=['discord']) + '?next=/admin/ffstream/')

--- a/ffsite/tests.py
+++ b/ffsite/tests.py
@@ -1,5 +1,8 @@
+from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
+
+TEST_PASSWORD = 'pass'
 
 
 class LoginErrorViewTest(TestCase):
@@ -90,3 +93,23 @@ class StreamViewTest(TestCase):
     def test_context_stream_url_none_when_not_set(self):
         response = self.client.get(reverse('stream'))
         self.assertIsNone(response.context['stream_url'])
+
+
+class AdminNavLinkTest(TestCase):
+    def setUp(self):
+        self.staff_user = User.objects.create_user('staff', is_staff=True, password=TEST_PASSWORD)
+        self.regular_user = User.objects.create_user('regular', is_staff=False, password=TEST_PASSWORD)
+
+    def test_admin_link_shown_for_staff(self):
+        self.client.login(username='staff', password=TEST_PASSWORD)
+        response = self.client.get(reverse('home'))
+        self.assertContains(response, reverse('admin:index'))
+
+    def test_admin_link_hidden_for_regular_user(self):
+        self.client.login(username='regular', password=TEST_PASSWORD)
+        response = self.client.get(reverse('home'))
+        self.assertNotContains(response, reverse('admin:index'))
+
+    def test_admin_link_hidden_when_not_logged_in(self):
+        response = self.client.get(reverse('home'))
+        self.assertNotContains(response, reverse('admin:index'))

--- a/ffsite/tests.py
+++ b/ffsite/tests.py
@@ -113,3 +113,22 @@ class AdminNavLinkTest(TestCase):
     def test_admin_link_hidden_when_not_logged_in(self):
         response = self.client.get(reverse('home'))
         self.assertNotContains(response, reverse('admin:index'))
+
+
+class AdminLoginDiscordButtonTest(TestCase):
+    def setUp(self):
+        from django.core.cache import cache
+        cache.clear()
+
+    @override_settings(
+        SOCIAL_AUTH_DISCORD_KEY='123456789012345678',
+        SOCIAL_AUTH_DISCORD_SECRET='abcDEF123_-abcDEF123_-abcDEF1234',
+    )
+    def test_discord_button_shown_when_credentials_valid(self):
+        response = self.client.get(reverse('admin:login'))
+        self.assertContains(response, reverse('social:begin', args=['discord']))
+
+    @override_settings(SOCIAL_AUTH_DISCORD_KEY='', SOCIAL_AUTH_DISCORD_SECRET='')
+    def test_discord_button_hidden_when_credentials_not_set(self):
+        response = self.client.get(reverse('admin:login'))
+        self.assertNotContains(response, reverse('social:begin', args=['discord']))

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,11 @@
+{% extends "admin/login.html" %}
+{% load i18n %}
+
+{% block content %}
+{{ block.super }}
+{% if discord_login_enabled %}
+<div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid #ccc; text-align: center;">
+    <a href="{% url 'social:begin' 'discord' %}" class="button">{% trans "Login with Discord" %}</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -4,7 +4,7 @@
 {% block content %}
 {{ block.super }}
 {% if discord_login_enabled %}
-<div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid #ccc; text-align: center;">
+<div style="margin: 2rem auto 0; padding-top: 1.5rem; border-top: 1px solid #ccc; text-align: center; max-width: 28em;">
     <a href="{% url 'social:begin' 'discord' %}" class="button">{% trans "Login with Discord" %}</a>
 </div>
 {% endif %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,11 +1,20 @@
 {% extends "admin/login.html" %}
 {% load i18n %}
 
+{% block extrahead %}
+{{ block.super }}
+{% if discord_login_enabled %}
+<style>
+  #content-main { margin-bottom: 2rem; }
+</style>
+{% endif %}
+{% endblock %}
+
 {% block content %}
 {{ block.super }}
 {% if discord_login_enabled %}
-<div style="margin: 2rem auto 0; padding-top: 1.5rem; border-top: 1px solid #ccc; text-align: center; max-width: 28em;">
-    <a href="{% url 'social:begin' 'discord' %}" class="button">{% trans "Login with Discord" %}</a>
+<div style="padding-top: 1.5rem; border-top: 1px solid #ccc; text-align: center; max-width: 28em; margin: 0 auto;">
+    <a href="{% url 'social:begin' 'discord' %}?next={{ request.GET.next|default:'/admin/' }}" class="button">{% trans "Login with Discord" %}</a>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

Two staff-facing UX improvements: an Admin link in the navbar for staff users, and a Discord login button on the Django admin login page.

## Changes

### Admin link in navbar
- Added **Admin** link to the navbar, visible only to authenticated users with \`is_staff=True\`
- Appears between My Stream Keys and Logout

### Discord login button on admin page
- Created \`templates/admin/login.html\` to override the Django admin login template
- Adds a "Login with Discord" button below the standard form, shown only when Discord credentials are configured (\`discord_login_enabled\`)
- Button passes \`?next=\` through to the OAuth flow so users are redirected back to the admin site (or the originally requested admin URL) after login
- Added project-level \`templates/\` directory to \`TEMPLATES DIRS\` in settings and to \`Dockerfile.web\` COPY steps
- Separator line and spacing styled to match the admin form width

### Tests (27 ffsite tests, up from 14)
- Admin nav link shown for staff, hidden for regular users and anonymous
- Discord button shown/hidden based on credential validity
- Discord button includes correct \`?next=/admin/\` default
- Discord button preserves custom \`?next=\` param from admin login URL
- \`join\` and \`contact\` views return 200
- \`localtime\` template filter renders correct HTML with and without explicit \`eid\`
- \`random_contact\` returns a participant when one exists, empty model when none

## Test plan

- [x] 324 tests passing locally