### PR TITLE
Support vanity slugs in Extra Life participant and team API lookups

### DIFF
--- a/extralifeapi/participants.py
+++ b/extralifeapi/participants.py
@@ -36,7 +36,7 @@ class Participants(DonorDriveBase):
         return 'participants'
 
     def sub_by_pid(self, participantID):
-        return 'participants/%d' % participantID
+        return 'participants/%s' % participantID
 
     def sub_by_eid(self, eventID):
         return 'events/%d/participants' % eventID

--- a/extralifeapi/teams.py
+++ b/extralifeapi/teams.py
@@ -30,7 +30,7 @@ class Teams(DonorDriveBase):
         return 'teams'
 
     def sub_team_by_tid(self, teamID):
-        return 'teams/%d' % teamID
+        return 'teams/%s' % teamID
 
     def sub_team_by_eid(self, eventID):
         return 'events/%d/teams' % eventID

--- a/extralifeapi/tests.py
+++ b/extralifeapi/tests.py
@@ -602,6 +602,18 @@ class ParticipantFetchTest(TestCase):
         self.assertEqual(result.displayName, 'Liam Bonham')
         self.assertEqual(result.teamID, 8775)
 
+    @patch('extralifeapi.base.time')
+    def test_participant_accepts_vanity_slug(self, mock_time):
+        data = {'participantID': 19265, 'displayName': 'Liam Bonham', 'eventID': 508,
+                'teamID': 8775, 'fundraisingGoal': 8000.0, 'sumDonations': 0.0, 'numDonations': 0}
+        self.client.session.get = MagicMock(return_value=_mock_response(json_data=data))
+
+        result = self.client.participant('liambonham2024')
+
+        called_url = self.client.session.get.call_args[0][0]
+        self.assertIn('participants/liambonham2024', called_url)
+        self.assertEqual(result.participantID, 19265)
+
 
 class DonationMappingTest(TestCase):
     def test_maps_all_api_fields_to_namedtuple(self):
@@ -704,6 +716,16 @@ class TeamsFetchTest(TestCase):
 
         called_url = self.client.session.get.call_args[0][0]
         self.assertIn('teams/8775', called_url)
+
+    @patch('extralifeapi.base.time')
+    def test_team_accepts_vanity_slug(self, mock_time):
+        self.client.session.get = MagicMock(return_value=_mock_response(json_data=_TEAM_DATA))
+
+        result = self.client.team('fragforce-dcm')
+
+        called_url = self.client.session.get.call_args[0][0]
+        self.assertIn('teams/fragforce-dcm', called_url)
+        self.assertEqual(result.teamID, 8775)
 
     @patch('extralifeapi.base.time')
     def test_teams_yields_team_namedtuples(self, mock_time):


### PR DESCRIPTION
## Summary

The DonorDrive API supports both numeric IDs and vanity slugs for participants and teams:
- `https://www.extra-life.org/participants/511438` (numeric)
- `https://www.extra-life.org/participants/aevumdecessus` (vanity)
- `https://www.extra-life.org/teams/fragforce-dcm` (team vanity)

Previously `sub_by_pid` and `sub_team_by_tid` used `%d` formatting which would raise a TypeError on string slugs. Changed both to `%s` so the API client accepts either form. The API resolves vanity slugs server-side and returns the full object including the numeric ID.

## Changes

- `extralifeapi/participants.py` - `sub_by_pid` uses `%s` instead of `%d`
- `extralifeapi/teams.py` - `sub_team_by_tid` uses `%s` instead of `%d`
- `extralifeapi/tests.py` - added `test_participant_accepts_vanity_slug` and `test_team_accepts_vanity_slug`

## Test plan

- [x] 70 extralifeapi tests passing