### PR TITLE
Fix IndexError when team API returns empty response

### DIFF
--- a/extralifeapi/teams.py
+++ b/extralifeapi/teams.py
@@ -53,7 +53,10 @@ class Teams(DonorDriveBase):
 
     def team(self, teamID):
         """ Get a team """
-        fresp = list(self.fetch(sub_url=self.sub_team_by_tid(teamID)))[0]
+        results = list(self.fetch(sub_url=self.sub_team_by_tid(teamID)))
+        if not results:
+            raise IndexError(f"No team found for teamID={teamID}")
+        fresp = results[0]
         self.log.info("fresp=", extra=dict(fresp=fresp))
         return self._team_to_team(fresp)
 

--- a/ffdonations/tasks/teams.py
+++ b/ffdonations/tasks/teams.py
@@ -65,8 +65,8 @@ def update_teams(self, teams=None):
     for tid in teams:
         try:
             el_teams.append(el_api.team(teamID=int(tid)))
-        except HTTPError as e:
-            if e.response is not None and e.response.status_code == 404:
+        except (HTTPError, IndexError) as e:
+            if isinstance(e, IndexError) or (e.response is not None and e.response.status_code == 404):
                 try:
                     tm = TeamModel.objects.get(id=int(tid))
                     tm.tracked = False


### PR DESCRIPTION
The `team()` method in `extralifeapi/teams.py` was taking `[0]` directly from the API response without checking if the list was empty, causing an `IndexError` crash in the Celery worker when a team ID returns no data.

- `extralifeapi/teams.py` - check for empty result and raise `IndexError` with a descriptive message
- `ffdonations/tasks/teams.py` - catch `IndexError` alongside `HTTPError`, treating it the same as a 404 (untrack the team)