### PR TITLE
Fix: Pin pipenv version in Dockerfiles and CI; remove unused asdf

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install pipenv && pipenv install --dev
+        run: pip install pipenv==2026.5.2 && pipenv install --dev
 
       - name: Run tests with coverage
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Base Image
 FROM python:3.10
-RUN pip install pipenv
+RUN pip install pipenv==2026.5.2
 
 # Having an editor is very nice
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.beat
+++ b/Dockerfile.beat
@@ -10,8 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml py
 FROM base AS python-deps
 
 # Install pipenv and compilation dependencies
-RUN pip install --upgrade pip
-RUN pip install pipenv asdf
+RUN pip install pipenv==2026.5.2
 RUN apt-get update && apt-get install -y --no-install-recommends gcc git && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies in /.venv

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -10,8 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml py
 FROM base AS python-deps
 
 # Install pipenv and compilation dependencies
-RUN pip install --upgrade pip
-RUN pip install pipenv asdf
+RUN pip install pipenv==2026.5.2
 RUN apt-get update && apt-get install -y --no-install-recommends gcc git python3-dev && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies in /.venv

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -10,8 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-lxml py
 FROM base AS python-deps
 
 # Install pipenv and compilation dependencies
-RUN pip install --upgrade pip
-RUN pip install pipenv asdf
+RUN pip install pipenv==2026.5.2
 RUN apt-get update && apt-get install -y --no-install-recommends gcc git && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies in /.venv


### PR DESCRIPTION
## Summary

Fixes 18 SonarCloud security vulnerabilities (C security rating → A) in all Dockerfiles and CI workflow.

- Pins `pipenv==2026.5.2` instead of `pip install pipenv` (unlocked)
- Removes `pip install --upgrade pip` (redundant — `pipenv install --deploy` installs the locked `pip==26.1` into the venv)
- Removes `asdf` which was installed but never used
- Same fix in `.github/workflows/coverage.yaml`

## Merged PRs
- #948 — Fix: Pin pipenv version in Dockerfiles and CI; remove unused asdf

## Test plan
- [x] Docker images build successfully
- [x] fragdev: containers start and app runs correctly after rebuild
- [x] SonarCloud Quality Gate passes