### PR TITLE
Add ADD_DISCORD_COMMANDS setting to gate /stream-key slash command registration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,14 +32,15 @@ All developer scripts live in `dev/` and can be run from the repo root.
 |--------|-------------|
 | `dev/start.sh` | Start the dev stack. Detects first run and handles setup automatically. |
 | `dev/update.sh` | Pull latest changes, rebuild image if dependencies changed, and run migrations. |
-| `dev/reset.sh` | Tear down volumes and restart. Use `--clean` to also remove built images and force a full Docker rebuild. |
-| `dev/shell.sh [bash\|django\|db\|hc]` | Open a shell in the web container: bash (default), Django shell, dbshell, or HC dbshell. |
+| `dev/reset.sh [--clean] [--force]` | Tear down volumes and restart. `--clean` also removes built images forcing a full Docker rebuild. `--force` skips the confirmation prompt. |
+| `dev/shell.sh [bash\|django\|db]` | Open a shell in the web container: `bash` (default), `django` (Django shell), `db` (dbshell). |
 | `dev/lint.sh [dir]` | Run pyflakes across all Python files (or a specific app directory). |
-| `dev/logs.sh [service]` | Tail logs for a service. Defaults to `web`. |
+| `dev/logs.sh [service]` | Tail logs for a service (`web` default; also `worker`, `beat`, `db`, `redis`). |
 | `dev/migrate.sh [app]` | Run pending migrations (all apps, or a specific one). |
-| `dev/makemigrations.sh [app]` | Create migrations for model changes (all apps, or a specific one). |
-| `dev/runtests.sh [target]` | Run tests and format output as a GitHub-ready markdown comment. |
-| `dev/pr.sh "Title" [--base branch] [--skip-tests]` | Run tests, push branch, and open a PR with test results embedded in the body. Aborts if tests fail. Requires `gh`. Defaults to `dev` as the base branch. |
+| `dev/makemigrations.sh [app]` | Create migrations for model changes (all apps, or a specific one). Passes through any extra Django args (e.g. `--check`). |
+| `dev/runtests.sh [--fresh] [target]` | Run tests and format output as a GitHub-ready markdown comment. `--fresh` drops and recreates the test DB first. |
+| `dev/coverage.sh [app]` | Run tests with coverage and print a full coverage report sorted by worst coverage first. |
+| `dev/pr.sh "Title" [--base branch] [--body "desc"] [--skip-tests]` | Run tests, push branch, and open a PR with test results embedded in the body. Aborts if tests fail. Requires `gh`. Defaults to `dev` as the base branch. |
 
 ## Running Tests
 
@@ -74,14 +75,110 @@ python manage.py collectstatic --no-input
 
 ## Environment Variables
 
-Copy `env.sample` to `.env` to get started. Key variables:
+Copy `env.sample` to `.env` to get started. All optional variables have sensible defaults — only set them if you need to override.
+
+### Required
 
 | Variable | Description |
 |----------|-------------|
-| `SECRET_KEY` | Django secret key |
-| `EXTRALIFE_TEAMID` | Extra Life team ID to sync |
-| `TILTIFY_TOKEN` / `TILTIFY_TEAMS` | Tiltify auth and team slugs |
-| `FRAG_BOT_API` / `FRAG_BOT_KEY` | Twitch bot integration |
-| `REDIS_URL` | Redis connection URL |
+| `SECRET_KEY` | Django secret key (generate with `python -c "import secrets; print(secrets.token_urlsafe(50))"`) |
 
-See `env.sample` and `fforg/settings.py` for the full list.
+### Redis
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REDIS_URL` | `redis://localhost` | Single Redis instance (split across DB indexes 0-4) |
+| `REDIS0_URL`-`REDIS4_URL` | - | Override individual Redis DB URLs (default, tasks, tombs, timers, cache) |
+
+### Discord OAuth2
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISCORD_CLIENT_ID` | - | OAuth2 app client ID |
+| `DISCORD_CLIENT_SECRET` | - | OAuth2 app client secret |
+| `DISCORD_GUILD_ID` | `164136635762606081` | Required guild; users not in this guild are denied login |
+
+### Discord Bot
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISCORD_BOT_TOKEN` | - | Bot token for role sync and slash commands |
+| `ADD_DISCORD_COMMANDS` | `true` | Set to `false` to start the bot without registering slash commands |
+| `DISCORD_ROLE_SYNC_HOURS` | `1` | How often to sync Discord roles (hours) |
+| `DISCORD_MEMBER_SYNC_MINUTES` | `15` | How often to sync guild member roles (minutes) |
+
+### Extra Life / DonorDrive
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EXTRALIFE_TEAMID` | `73149` | Extra Life team ID to sync |
+| `MIN_EL_TEAMID` | `73127` | Minimum valid team ID |
+| `MIN_EL_PARTICIPANTID` | `565075` | Minimum valid participant ID |
+| `EL_EVENT_ID` | `-1` | Extra Life event ID filter (-1 = all) |
+| `EL_REQUEST_MIN_TIME_SECONDS` | `15` | Minimum time between API requests |
+| `EL_REQUEST_MIN_TIME_URL_SECONDS` | `15` | Minimum time between requests to the same URL |
+| `EL_RETRY_AFTER_SECONDS` | `60` | Delay after a rate-limit response |
+| `EL_MAX_RETRIES` | `3` | Max retries on rate-limit |
+| `EL_SERVER_RETRY_AFTER_SECONDS` | `600` | Delay after a server error |
+| `EL_SERVER_MAX_RETRIES` | `6` | Max retries on server error |
+| `REQUEST_MIN_TIME_HOST_SECONDS` | `15` | Minimum time between requests to the same host |
+
+### Tiltify
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TILTIFY_TOKEN` | - | Tiltify API token |
+| `TILTIFY_TEAMS` | `fragforce` | Comma-separated team slugs |
+| `TILTIFY_TIMEOUT` | `60` | API request timeout (seconds) |
+| `TILTIFY_APP_OWNER` | - | Tiltify app owner slug |
+
+### Twitch Bot Integration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FRAG_BOT_API` | `https://bot.fragforce.org/dbquery` | Twitch bot API endpoint |
+| `FRAG_BOT_KEY` | - | API key |
+| `FRAG_BOT_BOT` | `misterfragbot` | Bot username |
+
+### Donations
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SINGAPORE_DONATIONS` | `0.0` | Manual donation adjustment (SGD region) |
+| `OTHER_DONATIONS` | `0.0` | Manual donation adjustment (other) |
+| `TARGET_DONATIONS` | `1.0` | Donation goal override |
+| `SEND_MISSED_DONATIONS` | `10` | Minutes of missed donations to re-announce |
+
+### Streaming
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STREAM_URL` | - | Stream URL |
+| `STREAM_DASH_BASE` | `https://stream.fragforce.org` | DASH stream server base URL |
+
+### Django / Performance
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEBUG` | `True` | Django debug mode |
+| `DJANGO_LOG_LEVEL` | `INFO` | Log level |
+| `MAX_API_ROWS` | `1024` | Max rows returned by API endpoints |
+| `GOOGLE_ANALYTICS_ID` | - | GA tracking ID |
+| `MAX_UPCOMING_EVENTS` | `20` | Max upcoming events shown |
+| `MAX_PAST_EVENTS` | `20` | Max past events shown |
+| `DOCKER` | `False` | Use Docker database config |
+| `DOCKER_PROD` | `False` | Use Docker production database config |
+
+### View Cache Timeouts (seconds)
+
+| Variable | Default |
+|----------|---------|
+| `VIEW_TEAMS_CACHE` | `20` |
+| `VIEW_PARTICIPANTS_CACHE` | `20` |
+| `VIEW_DONATIONS_CACHE` | `20` |
+| `VIEW_DONATIONS_STATS_CACHE` | `20` |
+| `VIEW_SITE_EVENT_CACHE` | `60` |
+| `VIEW_SITE_SITE_CACHE` | `60` |
+| `VIEW_SITE_STATIC_CACHE` | `300` |
+
+See `env.sample` for a commented template of all variables.

--- a/env.sample
+++ b/env.sample
@@ -14,6 +14,7 @@ DISCORD_GUILD_ID=164136635762606081
 
 # Discord Bot - bot token from the same app
 DISCORD_BOT_TOKEN=
+# ADD_DISCORD_COMMANDS=true  # Set to false to start the bot without registering slash commands
 
 # Discord sync schedules
 # DISCORD_ROLE_SYNC_HOURS=1

--- a/ffbot/management/commands/run_discord_bot.py
+++ b/ffbot/management/commands/run_discord_bot.py
@@ -28,29 +28,32 @@ class Command(BaseCommand):
         async def on_ready():
             log.info("Fragforce bot logged in as %s (ID: %s)", bot.user, bot.user.id)
 
-        @bot.slash_command(
-            name="stream-key",
-            description="Fetch your stream key",
-            guild_ids=guild_ids,
-        )
-        async def stream_key(ctx):
-            discord_id = str(ctx.author.id)
-            discord_username = ctx.author.name
-
-            role_ids = [str(r.id) for r in ctx.author.roles]
-
-            def get_key():
-                user = get_or_register_user(discord_id, discord_username)
-                sync_user_roles(user, role_ids)
-                return get_or_create_stream_key(user)
-
-            key = await sync_to_async(get_key)()
-
-            await ctx.respond(
-                f"**Your Stream Key:** `{key.stream_key}`\n"
-                f"Super Stream: {'Yes' if key.superstream else 'No'} | "
-                f"Direct Livestream: {'Yes' if key.livestream else 'No'}",
-                ephemeral=True,
+        if settings.ADD_DISCORD_COMMANDS:
+            @bot.slash_command(
+                name="stream-key",
+                description="Fetch your stream key",
+                guild_ids=guild_ids,
             )
+            async def stream_key(ctx):
+                discord_id = str(ctx.author.id)
+                discord_username = ctx.author.name
+
+                role_ids = [str(r.id) for r in ctx.author.roles]
+
+                def get_key():
+                    user = get_or_register_user(discord_id, discord_username)
+                    sync_user_roles(user, role_ids)
+                    return get_or_create_stream_key(user)
+
+                key = await sync_to_async(get_key)()
+
+                await ctx.respond(
+                    f"**Your Stream Key:** `{key.stream_key}`\n"
+                    f"Super Stream: {'Yes' if key.superstream else 'No'} | "
+                    f"Direct Livestream: {'Yes' if key.livestream else 'No'}",
+                    ephemeral=True,
+                )
+        else:
+            log.info("ADD_DISCORD_COMMANDS is disabled - skipping /stream-key registration")
 
         bot.run(settings.DISCORD_BOT_TOKEN)

--- a/ffbot/tests.py
+++ b/ffbot/tests.py
@@ -1,5 +1,7 @@
+from unittest.mock import MagicMock, patch
+
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from ffbot.utils import get_or_create_stream_key, get_or_register_user
 from ffstream.models import Key
@@ -79,3 +81,26 @@ class GetOrCreateStreamKeyTest(TestCase):
             result = get_or_create_stream_key(self.user)
         self.assertNotEqual(result.stream_key, existing.stream_key)
         self.assertGreaterEqual(call_count['n'], 2)
+
+
+class AddDiscordCommandsSettingTest(TestCase):
+    def _run_handle(self):
+        """Run Command.handle() with Discord and bot token validation mocked out."""
+        from ffbot.management.commands.run_discord_bot import Command
+        mock_bot = MagicMock()
+        with patch('ffbot.management.commands.run_discord_bot.discord_bot_token_valid', return_value=True), \
+             patch('ffbot.management.commands.run_discord_bot.discord.Bot', return_value=mock_bot):
+            Command().handle()
+        return mock_bot
+
+    @override_settings(ADD_DISCORD_COMMANDS=True)
+    def test_slash_command_registered_when_enabled(self):
+        mock_bot = self._run_handle()
+        mock_bot.slash_command.assert_called_once()
+        _, kwargs = mock_bot.slash_command.call_args
+        self.assertEqual(kwargs.get('name'), 'stream-key')
+
+    @override_settings(ADD_DISCORD_COMMANDS=False)
+    def test_slash_command_not_registered_when_disabled(self):
+        mock_bot = self._run_handle()
+        mock_bot.slash_command.assert_not_called()

--- a/fforg/settings.py
+++ b/fforg/settings.py
@@ -467,6 +467,7 @@ SOCIAL_AUTH_DISCORD_SCOPE = ['identify', 'email', 'guilds']
 SOCIAL_AUTH_DISCORD_AUTH_EXTRA_ARGUMENTS = {'prompt': 'consent'}
 DISCORD_REQUIRED_GUILD_ID = os.environ.get('DISCORD_GUILD_ID', '164136635762606081')
 DISCORD_BOT_TOKEN = os.environ.get('DISCORD_BOT_TOKEN', '')
+ADD_DISCORD_COMMANDS = os.environ.get('ADD_DISCORD_COMMANDS', 'true').lower() not in ('false', '0', 'no')
 
 SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',


### PR DESCRIPTION
## Summary

Add `ADD_DISCORD_COMMANDS` setting (default `true`) to gate whether the `/stream-key` slash command is registered when the Discord bot starts.

Set `ADD_DISCORD_COMMANDS=false` in the environment to start the bot without registering any slash commands.

## Changes

- `fforg/settings.py`: `ADD_DISCORD_COMMANDS = os.environ.get('ADD_DISCORD_COMMANDS', 'true').lower() not in ('false', '0', 'no')`
- `ffbot/management/commands/run_discord_bot.py`: wrap slash command registration in `if settings.ADD_DISCORD_COMMANDS`; logs when skipped
- `ffbot/tests.py`: two new tests verifying command is registered when enabled and not registered when disabled

## Test plan

- [x] 13 ffbot tests pass
- [x] `ADD_DISCORD_COMMANDS=true` (default): `/stream-key` registered as expected
- [x] `ADD_DISCORD_COMMANDS=false`: `/stream-key` not registered, log message emitted
