### PR TITLE
Coverage: always upload artifacts so SonarCloud fires on test failures

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -54,6 +54,7 @@ jobs:
         run: pip install pipenv==2026.5.2 && pipenv install --dev
 
       - name: Run tests with coverage
+        continue-on-error: true
         env:
           DOCKER: "True"
           DATABASE_URL: postgres://postgres:insecure@localhost/fragforce_test
@@ -72,7 +73,7 @@ jobs:
           echo "${{ github.ref_name }}" > branch_name.txt
 
       - name: Upload coverage and test artifacts
-        if: success()
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary

The Coverage workflow was blocking SonarCloud from running whenever tests failed, since artifacts were only uploaded on `success()`. This meant broken PRs got no quality gate feedback at all.

Changes:
- `continue-on-error: true` on the test step so coverage.xml is always generated
- `if: always()` on the artifact upload so SonarCloud always has what it needs

Test failures are still visible via the Django Tests check that the SonarCloud workflow posts back to the PR.

## Validation

PR #955 has failing tests due to `Game.slug` removal - this PR should cause SonarCloud to fire on that PR even with the test failures.