### PR TITLE
Split Django Tests into own workflow; fail on test failures

### DIFF
--- a/.github/workflows/django-tests.yaml
+++ b/.github/workflows/django-tests.yaml
@@ -1,0 +1,42 @@
+name: Django Tests
+
+on:
+  workflow_run:
+    workflows: ["Coverage"]
+    types:
+      - completed
+
+jobs:
+  report:
+    name: Django Tests
+    if: github.repository == 'fragforce/fragforce.org'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          client-id: ${{ secrets.FRAGFORCE_CI_APP_ID }}
+          private-key: ${{ secrets.FRAGFORCE_CI_PRIVATE_KEY }}
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Report test results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        with:
+          name: Django Tests
+          path: TEST-*.xml
+          reporter: java-junit
+          fail-on-error: true
+          use-actions-summary: true
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -37,16 +37,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Report test results
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
-        with:
-          name: Django Tests
-          path: TEST-*.xml
-          reporter: java-junit
-          fail-on-error: false
-          use-actions-summary: false
-          token: ${{ steps.app-token.outputs.token }}
-
       - name: Set scan properties
         run: |
           # Read artifact files and sanitize values before writing to GITHUB_ENV


### PR DESCRIPTION
## Summary

The Django Tests check previously ran inside the SonarCloud workflow with `fail-on-error: false`, meaning it always showed green regardless of test failures. This was fixed by splitting it out:

- New **Django Tests** workflow (`.github/workflows/django-tests.yaml`) - triggers on Coverage completion, downloads test XML artifacts, reports results with `fail-on-error: true` and `use-actions-summary: true`. Goes red when tests fail.
- **SonarCloud** workflow - `Report test results` step removed; it no longer has any dependency on test pass/fail status.

Result:
- Coverage always succeeds (from PR #957) so SonarCloud always fires
- Django Tests shows red when tests fail
- SonarCloud quality gate runs independently of test status
