### PR TITLE
Fix Django Tests workflow: add missing checkout step

### DIFF
--- a/.github/workflows/django-tests.yaml
+++ b/.github/workflows/django-tests.yaml
@@ -17,6 +17,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout PR code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3


### PR DESCRIPTION
## Summary

`dorny/test-reporter` requires a git checkout to post check runs - it uses git internally to determine the commit SHA. The Django Tests workflow was missing this step, causing the job to fail with `git failed with exit code 128` before it could report any results.
