### PR TITLE
Fix Django Tests check posting to wrong commit SHA

### DIFF
--- a/.github/workflows/django-tests.yaml
+++ b/.github/workflows/django-tests.yaml
@@ -45,3 +45,4 @@ jobs:
           fail-on-error: true
           use-actions-summary: true
           token: ${{ steps.app-token.outputs.token }}
+          commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary

`dorny/test-reporter` was posting the Django Tests check against the dev branch merge commit instead of the PR's head commit, so it never appeared on the PR's check list.

Pass `commit: ${{ github.event.workflow_run.head_sha }}` explicitly so the check is posted against the correct commit SHA.
