### PR TITLE
Switch Django Tests to mikepenz/action-junit-report for correct PR commit SHA

### DIFF
--- a/.github/workflows/django-tests.yaml
+++ b/.github/workflows/django-tests.yaml
@@ -17,11 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout PR code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
@@ -37,12 +32,12 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Report test results
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
-          name: Django Tests
-          path: TEST-*.xml
-          reporter: java-junit
-          fail-on-error: true
-          use-actions-summary: true
-          token: ${{ steps.app-token.outputs.token }}
+          report_paths: TEST-*.xml
+          check_name: Django Tests
           commit: ${{ github.event.workflow_run.head_sha }}
+          token: ${{ steps.app-token.outputs.token }}
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true


### PR DESCRIPTION
## Summary

`dorny/test-reporter` ignores the `commit` input and always posts the check against `GITHUB_SHA` (the default branch merge commit in a `workflow_run` context), so the Django Tests check never appeared on the PR.

Switch to `mikepenz/action-junit-report` which properly supports a `commit` override - it passes it directly as `head_sha` to the GitHub checks API. The checkout step is no longer needed since the SHA is passed explicitly.

- `commit: ${{ github.event.workflow_run.head_sha }}` - posts check to the PR's actual commit
- `fail_on_failure: true` - goes red when tests fail
- `detailed_summary: true` - shows formatted test results with failure details
- `include_passed: true` - shows full test suite summary
