### PR TITLE
Fix Participants.participant() called as classmethod

### DIFF
--- a/evtsignup/tasks.py
+++ b/evtsignup/tasks.py
@@ -133,7 +133,7 @@ def _resolve_participant(interest, result):
     )
 
     try:
-        api_participant = Participants.participant(id_or_slug)
+        api_participant = Participants().participant(id_or_slug)
     except Exception as e:
         log.warning(
             'resolve_fundraising_url: failed to fetch participant %s: %s',


### PR DESCRIPTION
## Summary

`Participants.participant(id_or_slug)` was called as a classmethod but it's an instance method on `DonorDriveBase`. This caused a blocker in the full SonarCloud branch scan (not caught by PR analysis due to incremental analysis limitations).

Fix: call as `Participants().participant(id_or_slug)`.
