### PR TITLE
Address PR #966 review: signal reentrancy, N+1 saves, docstring, settings default

### DIFF
--- a/eventer/tasks.py
+++ b/eventer/tasks.py
@@ -115,17 +115,18 @@ def close_signups_for_started_events():
     """
     Auto-close signups for events that have started.
     Sets signups_open=False on any Event where the earliest period has started
-    and signups_open is still True.
+    and signups_open is still True. Uses a single annotated UPDATE to avoid N+1 saves.
     """
+    from django.db.models import Min
     from django.utils import timezone
     from eventer.models import Event
 
     now = timezone.now()
-    closed = 0
-    for event in Event.objects.filter(signups_open=True):
-        if event.start and event.start <= now:
-            event.signups_open = False
-            event.save(update_fields=['signups_open'])
-            log.info('close_signups_for_started_events: closed signups for %s', event.name)
-            closed += 1
+    closed = (
+        Event.objects
+        .filter(signups_open=True)
+        .annotate(first_start=Min('eventperiod__start'))
+        .filter(first_start__lte=now)
+        .update(signups_open=False)
+    )
     log.info('close_signups_for_started_events: closed %d events', closed)

--- a/evtsignup/signals.py
+++ b/evtsignup/signals.py
@@ -44,10 +44,13 @@ def queue_fundraising_url_resolution(sender, instance, created, update_fields=No
         )
         return
 
-    # Reset attempt counter when URL changes so new URL gets fresh attempts
+    # Reset attempt counter when URL changes so new URL gets fresh attempts.
+    # Use queryset.update() to bypass signals and avoid re-entrant pre_save
+    # corrupting _prev_fundraising_url change-detection state.
     if not created and url_changed and instance.url_resolution_attempts > 0:
-        instance.url_resolution_attempts = 0
-        instance.save(update_fields=['url_resolution_attempts'])
+        from evtsignup.models import EventInterest
+        EventInterest.objects.filter(pk=instance.pk).update(url_resolution_attempts=0)
+        instance.url_resolution_attempts = 0  # keep in-memory state consistent
 
     from evtsignup.tasks import resolve_fundraising_url
     resolve_fundraising_url.delay(instance.pk)

--- a/evtsignup/tasks.py
+++ b/evtsignup/tasks.py
@@ -25,7 +25,7 @@ def resolve_fundraising_url(event_interest_id):
     from evtsignup.utils import parse_fundraising_url
 
     from django.conf import settings
-    max_attempts = settings.URL_RESOLUTION_MAX_ATTEMPTS
+    max_attempts = getattr(settings, 'URL_RESOLUTION_MAX_ATTEMPTS', 3)
 
     try:
         interest = EventInterest.objects.get(pk=event_interest_id)
@@ -98,10 +98,11 @@ def _is_followable_url(url):
 def _follow_redirect(url):
     """
     Follow HTTP redirects on a user-provided URL and return the final URL.
-    Only scheme + host + path are forwarded - query params, fragments, and credentials
-    are stripped to reduce attack surface. Only called after _is_followable_url() validates
-    the URL. The final URL is always re-parsed through parse_fundraising_url() before any
-    action is taken, so only known Extra Life domains produce side effects.
+    Query params/fragments are stripped from the *outgoing* request only to reduce attack
+    surface. The returned URL (resp.url) preserves whatever params the server redirected
+    to — parse_fundraising_url() relies on this to extract participant IDs from query strings.
+    Only called after _is_followable_url() validates the URL. The final URL is always
+    re-parsed through parse_fundraising_url() before any action is taken.
     """
     from urllib.parse import urlparse, urlunparse
     try:
@@ -176,7 +177,7 @@ def retry_pending_url_resolutions():
     """
     from django.conf import settings
     from evtsignup.models import EventInterest
-    max_attempts = settings.URL_RESOLUTION_MAX_ATTEMPTS
+    max_attempts = getattr(settings, 'URL_RESOLUTION_MAX_ATTEMPTS', 3)
     pending = EventInterest.objects.filter(
         fundraising_url__isnull=False,
         el_participant__isnull=True,


### PR DESCRIPTION
Addresses review comments on #966.

- **C1** — Signal reentrancy in `evtsignup/signals.py`: replaced `instance.save(update_fields=['url_resolution_attempts'])` with `queryset.update()` to bypass signals and avoid re-entrant `pre_save` corrupting `_prev_fundraising_url` change-detection state. In-memory `instance.url_resolution_attempts` still set to keep object consistent.
- **M1** — N+1 saves in `close_signups_for_started_events`: collapsed loop + per-event `save()` to a single annotated `UPDATE` using `Min('eventperiod__start')`.
- **M2** — Clarified `_follow_redirect` docstring: query params stripped from *outgoing* request only; `resp.url` preserves server-redirected params as `parse_fundraising_url()` depends on them for participant ID extraction.
- **M3** — `URL_RESOLUTION_MAX_ATTEMPTS` now accessed via `getattr(settings, 'URL_RESOLUTION_MAX_ATTEMPTS', 3)` to handle minimal test configs.
