### PR TITLE
Add requirements version check script; upgrade wcwidth; pip-compile --upgrade-package support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,6 +33,7 @@ All developer scripts live in `dev/` and can be run from the repo root.
 | `dev/start.sh` | Start the dev stack. Detects first run and handles setup automatically. |
 | `dev/update.sh` | Pull latest changes, rebuild image if dependencies changed, and run migrations. |
 | `dev/pip-compile.sh [prod\|ci\|dev] [--upgrade]` | Regenerate pip-tools lockfiles inside the dev container. Defaults to all three. `--upgrade` allows version upgrades. |
+| `dev/check-requirements.sh [--quiet]` | Check for version differences between the three lockfiles. Exits 1 if any shared package is at different versions. |
 | `dev/reset.sh [--clean] [--force]` | Tear down volumes and restart. `--clean` also removes built images forcing a full Docker rebuild. `--force` skips the confirmation prompt. |
 | `dev/shell.sh [bash\|django\|db]` | Open a shell in the web container: `bash` (default), `django` (Django shell), `db` (dbshell). |
 | `dev/lint.sh [dir]` | Run pyflakes across all Python files (or a specific app directory). |

--- a/dev/check-requirements.sh
+++ b/dev/check-requirements.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Check for version differences between requirements.txt, requirements-ci.txt,
+# and requirements-dev.txt. Packages shared across files should be at the same version.
+#
+# Usage:
+#   dev/check-requirements.sh          # check for diffs, exit 1 if found
+#   dev/check-requirements.sh --quiet  # suppress output, only exit code
+
+cd "$(git rev-parse --show-toplevel)"
+
+QUIET="${1:-}"
+
+python3 - "$QUIET" << 'EOF'
+import sys
+import re
+
+quiet = sys.argv[1] == '--quiet'
+
+def parse(path):
+    versions = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip().rstrip(' \\')
+            m = re.match(r'^([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[.*?\])?==([^\s;]+)', line)
+            if m:
+                pkg = m.group(1).lower().replace('-', '_').replace('.', '_')
+                versions[pkg] = m.group(2)
+    return versions
+
+prod = parse('requirements.txt')
+ci   = parse('requirements-ci.txt')
+dev  = parse('requirements-dev.txt')
+
+all_pkgs = sorted(set(prod) | set(ci) | set(dev))
+diffs = []
+for pkg in all_pkgs:
+    p, c, d = prod.get(pkg), ci.get(pkg), dev.get(pkg)
+    present = [v for v in (p, c, d) if v]
+    if len(present) >= 2 and len(set(present)) > 1:
+        diffs.append((pkg, p or '-', c or '-', d or '-'))
+
+if diffs:
+    if not quiet:
+        print(f"{'Package':<40}  {'prod':<14}  {'ci':<14}  dev")
+        print('-' * 80)
+        for pkg, p, c, d in diffs:
+            print(f"{pkg:<40}  {p:<14}  {c:<14}  {d}")
+        print(f"\n{len(diffs)} package(s) have version differences between lockfiles.")
+        print("Run dev/pip-compile.sh to regenerate all three from pyproject.toml.")
+    sys.exit(1)
+else:
+    if not quiet:
+        print("All shared packages are at consistent versions across lockfiles.")
+    sys.exit(0)
+EOF

--- a/dev/pip-compile.sh
+++ b/dev/pip-compile.sh
@@ -2,11 +2,12 @@
 # Regenerate pip-tools lockfiles inside the dev container.
 #
 # Usage:
-#   dev/pip-compile.sh              # regenerate all three lockfiles
-#   dev/pip-compile.sh prod         # regenerate requirements.txt only
-#   dev/pip-compile.sh ci           # regenerate requirements-ci.txt only
-#   dev/pip-compile.sh dev          # regenerate requirements-dev.txt only
-#   dev/pip-compile.sh --upgrade    # regenerate all and allow upgrades
+#   dev/pip-compile.sh                          # regenerate all three lockfiles
+#   dev/pip-compile.sh prod                     # regenerate requirements.txt only
+#   dev/pip-compile.sh ci                       # regenerate requirements-ci.txt only
+#   dev/pip-compile.sh dev                      # regenerate requirements-dev.txt only
+#   dev/pip-compile.sh --upgrade                # regenerate all and allow upgrades
+#   dev/pip-compile.sh --upgrade-package <pkg>  # upgrade a single package across all files
 #
 # pip>=26 is ensured automatically before compiling.
 
@@ -23,20 +24,26 @@ if ! docker compose ps -q --status running web 2>/dev/null | grep -q .; then
 fi
 
 UPGRADE_FLAG=""
+UPGRADE_PACKAGE=""
 TARGET="all"
 
 # Ensure pip>=26 - older pip fails on kombu's setup.py (use_2to3 removed in setuptools 58+)
 docker compose exec -T web pip install --quiet "pip>=26" 2>/dev/null || true
 
-for arg in "$@"; do
-    case "$arg" in
-        --upgrade) UPGRADE_FLAG="--upgrade" ;;
-        prod|ci|dev) TARGET="$arg" ;;
-        *) echo "Unknown argument: $arg"; exit 1 ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --upgrade) UPGRADE_FLAG="--upgrade"; shift ;;
+        --upgrade-package) UPGRADE_PACKAGE="$2"; shift 2 ;;
+        prod|ci|dev) TARGET="$1"; shift ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
     esac
 done
 
-UPGRADE_OR_NO_UPGRADE="${UPGRADE_FLAG:---no-upgrade}"
+if [[ -n "$UPGRADE_PACKAGE" ]]; then
+    UPGRADE_OR_NO_UPGRADE="--upgrade-package $UPGRADE_PACKAGE"
+else
+    UPGRADE_OR_NO_UPGRADE="${UPGRADE_FLAG:---no-upgrade}"
+fi
 
 compile_prod() {
     echo "Compiling requirements.txt..."

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1587,9 +1587,9 @@ vine==5.1.0 \
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.6.0 \
-    --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
-    --hash=sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159
+wcwidth==0.7.0 \
+    --hash=sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2 \
+    --hash=sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0
     # via prompt-toolkit
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1205,9 +1205,9 @@ vine==5.1.0 \
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.6.0 \
-    --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
-    --hash=sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159
+wcwidth==0.7.0 \
+    --hash=sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2 \
+    --hash=sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0
     # via prompt-toolkit
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \


### PR DESCRIPTION
## Summary

- `dev/check-requirements.sh` — detects version skew between `requirements.txt`, `requirements-ci.txt`, and `requirements-dev.txt`; exits 1 if any shared package is at different versions across files
- `dev/pip-compile.sh` — added `--upgrade-package <pkg>` flag to upgrade a single package across all three lockfiles simultaneously
- Upgraded `wcwidth` from 0.6.0 → 0.7.0 (supersedes Dependabot PR #969)

## Usage

```bash
# Check for version skew
dev/check-requirements.sh

# Upgrade a single package across all lockfiles
dev/pip-compile.sh --upgrade-package wcwidth
```

## Test plan

- [x] `dev/check-requirements.sh` correctly detected wcwidth 0.6.0/0.7.0 skew before fix
- [x] After fix, `dev/check-requirements.sh` reports no differences
- [x] `dev/pip-compile.sh --upgrade-package wcwidth` updated all three files to 0.7.0
