### PR TITLE
Improve pip-compile.sh and check-requirements.sh dev scripts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,8 +32,8 @@ All developer scripts live in `dev/` and can be run from the repo root.
 |--------|-------------|
 | `dev/start.sh` | Start the dev stack. Detects first run and handles setup automatically. |
 | `dev/update.sh` | Pull latest changes, rebuild image if dependencies changed, and run migrations. |
-| `dev/pip-compile.sh [prod\|ci\|dev] [--upgrade]` | Regenerate pip-tools lockfiles inside the dev container. Defaults to all three. `--upgrade` allows version upgrades. |
-| `dev/check-requirements.sh [--quiet]` | Check for version differences between the three lockfiles. Exits 1 if any shared package is at different versions. |
+| `dev/pip-compile.sh [prod\|ci\|dev] [--upgrade] [--upgrade-package pkg]` | Regenerate pip-tools lockfiles inside the dev container. Defaults to all three. `--upgrade` upgrades all packages; `--upgrade-package pkg` upgrades a single package across all files. |
+| `dev/check-requirements.sh [--quiet\|--exclusive]` | Check for version differences between the three lockfiles (`--quiet` for exit-code only). `--exclusive` shows which packages are dev-only, ci+dev-only, or shared across all files - useful for evaluating Dependabot PR scope. |
 | `dev/reset.sh [--clean] [--force]` | Tear down volumes and restart. `--clean` also removes built images forcing a full Docker rebuild. `--force` skips the confirmation prompt. |
 | `dev/shell.sh [bash\|django\|db]` | Open a shell in the web container: `bash` (default), `django` (Django shell), `db` (dbshell). |
 | `dev/lint.sh [dir]` | Run pyflakes across all Python files (or a specific app directory). |
@@ -207,11 +207,19 @@ Dependencies are declared in `pyproject.toml` and locked in three files:
 To regenerate lockfiles after editing `pyproject.toml`:
 
 ```bash
-dev/pip-compile.sh           # regenerate all three
-dev/pip-compile.sh prod      # production only
-dev/pip-compile.sh ci        # CI only
-dev/pip-compile.sh dev       # dev only
-dev/pip-compile.sh --upgrade # upgrade all packages
+dev/pip-compile.sh                        # regenerate all three
+dev/pip-compile.sh prod                   # production only
+dev/pip-compile.sh ci                     # CI only
+dev/pip-compile.sh dev                    # dev only
+dev/pip-compile.sh --upgrade              # upgrade all packages
+dev/pip-compile.sh --upgrade-package django  # upgrade a single package across all files
+```
+
+To check for version skew between lockfiles (e.g. after a Dependabot PR):
+
+```bash
+dev/check-requirements.sh             # check for diffs, exits 1 if found
+dev/check-requirements.sh --exclusive # show which packages are dev/ci-only vs shared
 ```
 
 After regenerating, rebuild containers to pick up changes:

--- a/dev/check-requirements.sh
+++ b/dev/check-requirements.sh
@@ -3,18 +3,20 @@
 # and requirements-dev.txt. Packages shared across files should be at the same version.
 #
 # Usage:
-#   dev/check-requirements.sh          # check for diffs, exit 1 if found
-#   dev/check-requirements.sh --quiet  # suppress output, only exit code
+#   dev/check-requirements.sh              # check for diffs, exit 1 if found
+#   dev/check-requirements.sh --quiet      # suppress output, only exit code
+#   dev/check-requirements.sh --exclusive  # show which packages are exclusive to each file
+#                                           # (useful for evaluating Dependabot PRs)
 
 cd "$(git rev-parse --show-toplevel)"
 
-QUIET="${1:-}"
+MODE="${1:-}"
 
-python3 - "$QUIET" << 'EOF'
+python3 - "$MODE" << 'EOF'
 import sys
 import re
 
-quiet = sys.argv[1] == '--quiet'
+mode = sys.argv[1]
 
 def parse(path):
     versions = {}
@@ -31,6 +33,39 @@ prod = parse('requirements.txt')
 ci   = parse('requirements-ci.txt')
 dev  = parse('requirements-dev.txt')
 
+if mode == '--exclusive':
+    prod_set = set(prod)
+    ci_set   = set(ci)
+    dev_set  = set(dev)
+
+    dev_only    = sorted(dev_set - prod_set - ci_set)   # dev only
+    ci_dev_only = sorted((ci_set & dev_set) - prod_set)  # ci + dev, not prod
+    ci_only     = sorted(ci_set - prod_set - dev_set)    # ci only (currently none expected)
+
+    print("Dependabot PR scope guide:")
+    print()
+
+    print(f"  All 3 files (prod + ci + dev): everything in requirements.txt")
+    print(f"    → {len(prod_set - ci_set - dev_set) + len(prod_set & ci_set) + len(prod_set & dev_set)} packages shared with prod")
+
+    if ci_dev_only:
+        print(f"\n  ci + dev only ({len(ci_dev_only)}) - PRs should touch requirements-ci.txt and requirements-dev.txt:")
+        for p in ci_dev_only:
+            print(f"    {p}=={ci.get(p) or dev.get(p)}")
+
+    if dev_only:
+        print(f"\n  dev only ({len(dev_only)}) - PRs should touch requirements-dev.txt only:")
+        for p in dev_only:
+            print(f"    {p}=={dev[p]}")
+
+    if ci_only:
+        print(f"\n  ci only ({len(ci_only)}) - PRs should touch requirements-ci.txt only:")
+        for p in ci_only:
+            print(f"    {p}=={ci[p]}")
+
+    sys.exit(0)
+
+# Default: check for version skew
 all_pkgs = sorted(set(prod) | set(ci) | set(dev))
 diffs = []
 for pkg in all_pkgs:
@@ -39,6 +74,7 @@ for pkg in all_pkgs:
     if len(present) >= 2 and len(set(present)) > 1:
         diffs.append((pkg, p or '-', c or '-', d or '-'))
 
+quiet = mode == '--quiet'
 if diffs:
     if not quiet:
         print(f"{'Package':<40}  {'prod':<14}  {'ci':<14}  dev")

--- a/dev/pip-compile.sh
+++ b/dev/pip-compile.sh
@@ -24,7 +24,7 @@ if ! docker compose ps -q --status running web 2>/dev/null | grep -q .; then
 fi
 
 UPGRADE_FLAG=""
-UPGRADE_PACKAGE=""
+UPGRADE_PACKAGES=()
 TARGET="all"
 
 # Ensure pip>=26 - older pip fails on kombu's setup.py (use_2to3 removed in setuptools 58+)
@@ -33,14 +33,17 @@ docker compose exec -T web pip install --quiet "pip>=26" 2>/dev/null || true
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --upgrade) UPGRADE_FLAG="--upgrade"; shift ;;
-        --upgrade-package) UPGRADE_PACKAGE="$2"; shift 2 ;;
+        --upgrade-package) UPGRADE_PACKAGES+=("$2"); shift 2 ;;
         prod|ci|dev) TARGET="$1"; shift ;;
         *) echo "Unknown argument: $1"; exit 1 ;;
     esac
 done
 
-if [[ -n "$UPGRADE_PACKAGE" ]]; then
-    UPGRADE_OR_NO_UPGRADE="--upgrade-package $UPGRADE_PACKAGE"
+if [[ ${#UPGRADE_PACKAGES[@]} -gt 0 ]]; then
+    UPGRADE_OR_NO_UPGRADE=""
+    for pkg in "${UPGRADE_PACKAGES[@]}"; do
+        UPGRADE_OR_NO_UPGRADE="$UPGRADE_OR_NO_UPGRADE --upgrade-package $pkg"
+    done
 else
     UPGRADE_OR_NO_UPGRADE="${UPGRADE_FLAG:---no-upgrade}"
 fi


### PR DESCRIPTION
## Summary

Improvements to the `dev/pip-compile.sh` and `dev/check-requirements.sh` scripts introduced in #968.

### `dev/pip-compile.sh`

- Added support for multiple `--upgrade-package` flags: `dev/pip-compile.sh --upgrade-package celery --upgrade-package billiard`
- Previously only one package could be specified at a time

### `dev/check-requirements.sh`

- Added `--exclusive` flag showing which packages are exclusive to each lockfile tier
- Output classifies packages into three groups to guide Dependabot PR scope:
  - **All 3 files** (everything in `requirements.txt`) — Dependabot should update all three
  - **ci + dev only** (e.g. `coverage`, `lxml`, `unittest-xml-reporting`) — update ci and dev only
  - **dev only** (e.g. `ipython`, `pip-tools`, `pyflakes` and deps) — update dev only

### `DEVELOPMENT.md`

- Updated docs to reflect both new flags with usage examples

## Test plan

- [x] `dev/pip-compile.sh --upgrade-package wcwidth` (merged in #977 - upgraded wcwidth 0.6.0 → 0.7.0 across all lockfiles)
- [x] `dev/check-requirements.sh --exclusive` correctly identifies 22 dev-only and 3 ci+dev-only packages
