### PR TITLE
Watch all three lockfiles in update.sh for rebuild trigger

### DIFF
--- a/dev/update.sh
+++ b/dev/update.sh
@@ -14,17 +14,17 @@ if ! docker compose ps -q --status running web 2>/dev/null | grep -q .; then
     exit $?
 fi
 
-# Track whether requirements.txt changes after the pull
-LOCKFILE_BEFORE=$(git rev-parse HEAD:requirements.txt 2>/dev/null)
+# Track whether any lockfile changes after the pull
+LOCKFILE_BEFORE=$(git rev-parse HEAD:requirements.txt HEAD:requirements-dev.txt HEAD:requirements-ci.txt 2>/dev/null)
 
 echo "Pulling latest changes..."
 git pull --ff-only
 
-LOCKFILE_AFTER=$(git rev-parse HEAD:requirements.txt 2>/dev/null)
+LOCKFILE_AFTER=$(git rev-parse HEAD:requirements.txt HEAD:requirements-dev.txt HEAD:requirements-ci.txt 2>/dev/null)
 
 if [[ "$LOCKFILE_BEFORE" != "$LOCKFILE_AFTER" ]]; then
     echo ""
-    echo "requirements.txt changed - rebuilding image..."
+    echo "Requirements changed - rebuilding image..."
     docker compose build web
     docker compose up -d web
 fi


### PR DESCRIPTION
Addresses review comment on #983 from @parkervcp.

`dev/update.sh` only watched `requirements.txt` for changes, so adding a dev tool to `requirements-dev.txt` or a CI dep to `requirements-ci.txt` would silently skip the image rebuild. Developers would run with stale packages until manually rebuilding.

Now checks all three lockfiles before and after the pull.