### PR TITLE
Address blockers and high issues from #991 review

### DIFF
--- a/eventer/admin.py
+++ b/eventer/admin.py
@@ -300,26 +300,26 @@ class EventAdmin(admin.ModelAdmin):
                 for key in seen_keys:
                     try:
                         _, slot_pk, role_slug = key.split('_', 2)
-                        slot = slots_by_pk.get(int(slot_pk))
-                        role = roles_by_slug.get(role_slug)
-                        if not slot or not role:
-                            continue
-                        for user_id in request.POST.getlist(key):
-                            if not user_id:
-                                continue
-                            user = users_by_pk.get(int(user_id))
-                            if not user:
-                                continue
-                            if role_slug in multi_slugs:
-                                EventScheduleMultiAssignment.objects.create(event=event, slot=slot, role=role, user=user)
-                            else:
-                                game_id = request.POST.get(f'game_{slot_pk}') or None
-                                game = games_by_pk.get(int(game_id)) if game_id else None
-                                EventScheduleAssignment.objects.create(event=event, slot=slot, role=role, user=user, game=game)
-                            created += 1
-                    except Exception as e:
-                        log.warning('build_schedule_view: skipped key %s - %s', key, e)
+                    except (ValueError, AttributeError):
+                        log.warning('build_schedule_view: malformed POST key %r, skipping', key)
                         continue
+                    slot = slots_by_pk.get(int(slot_pk))
+                    role = roles_by_slug.get(role_slug)
+                    if not slot or not role:
+                        continue
+                    for user_id in request.POST.getlist(key):
+                        if not user_id:
+                            continue
+                        user = users_by_pk.get(int(user_id))
+                        if not user:
+                            continue
+                        if role_slug in multi_slugs:
+                            EventScheduleMultiAssignment.objects.create(event=event, slot=slot, role=role, user=user)
+                        else:
+                            game_id = request.POST.get(f'game_{slot_pk}') or None
+                            game = games_by_pk.get(int(game_id)) if game_id else None
+                            EventScheduleAssignment.objects.create(event=event, slot=slot, role=role, user=user, game=game)
+                        created += 1
             self.message_user(request, f"Schedule saved: {created} assignment(s).", messages.SUCCESS)
             return HttpResponseRedirect(f'../../{event_id}/build-schedule/')
 

--- a/eventer/admin.py
+++ b/eventer/admin.py
@@ -226,6 +226,13 @@ class EventAdmin(admin.ModelAdmin):
                         f"{result['deleted']} deleted.",
                         messages.SUCCESS,
                     )
+                    if result.get('empty_groups'):
+                        self.message_user(
+                            request,
+                            f"Warning: the following slot groups have no role memberships and were skipped: "
+                            f"{', '.join(result['empty_groups'])}. Add roles to these groups to generate slots for them.",
+                            messages.WARNING,
+                        )
                     return HttpResponseRedirect(f'../../{event_id}/change/')
                 except ValueError as e:
                     errors = str(e)

--- a/eventer/admin.py
+++ b/eventer/admin.py
@@ -205,30 +205,39 @@ class EventAdmin(admin.ModelAdmin):
         return render(request, 'admin/eventer/event/setup_superstream.html', context)
 
     def generate_slots_view(self, request, event_id):
+        from evtsignup.models import EventInterest
         event = get_object_or_404(Event, pk=event_id)
         errors = None
 
         if request.method == 'POST':
             replace = request.POST.get('replace') == '1'
-            try:
-                result = generate_slots(event, replace=replace)
-                self.message_user(
-                    request,
-                    f"Generated slots: {result['created']} created, "
-                    f"{result['skipped']} already existed, "
-                    f"{result['deleted']} deleted.",
-                    messages.SUCCESS,
+            signup_count = EventInterest.objects.filter(event=event).count()
+            if replace and signup_count > 0 and request.POST.get('confirm_replace_with_signups') != '1':
+                errors = (
+                    f"This event has {signup_count} existing signup(s). Check the confirmation box to proceed with regeneration."
                 )
-                return HttpResponseRedirect(f'../../{event_id}/change/')
-            except ValueError as e:
-                errors = str(e)
+            else:
+                try:
+                    result = generate_slots(event, replace=replace)
+                    self.message_user(
+                        request,
+                        f"Generated slots: {result['created']} created, "
+                        f"{result['skipped']} already existed, "
+                        f"{result['deleted']} deleted.",
+                        messages.SUCCESS,
+                    )
+                    return HttpResponseRedirect(f'../../{event_id}/change/')
+                except ValueError as e:
+                    errors = str(e)
 
         existing_slots = list(event.signup_slots.prefetch_related('roles').order_by('start'))
+        signup_count = EventInterest.objects.filter(event=event).count()
         context = {
             **self.admin_site.each_context(request),
             'event': event,
             'existing_slots': existing_slots,
             'existing_count': len(existing_slots),
+            'signup_count': signup_count,
             'errors': errors,
             'title': f'Generate Signup Slots - {event.name}',
         }

--- a/eventer/migrations/0026_eventrole_multi_assign_data.py
+++ b/eventer/migrations/0026_eventrole_multi_assign_data.py
@@ -3,7 +3,9 @@ from django.db import migrations
 
 def set_participant_multi_assign(apps, schema_editor):
     EventRole = apps.get_model('eventer', 'EventRole')
-    EventRole.objects.filter(slug='participant').update(multi_assign=True)
+    updated = EventRole.objects.filter(slug='participant').update(multi_assign=True)
+    if updated != 1:
+        raise ValueError(f"Expected to update 1 EventRole(slug='participant'), got {updated}. Run eventer migration 0024 first.")
 
 
 class Migration(migrations.Migration):

--- a/eventer/migrations/0028_eventrole_display_order_data.py
+++ b/eventer/migrations/0028_eventrole_display_order_data.py
@@ -11,7 +11,9 @@ DISPLAY_ORDERS = {
 def set_display_orders(apps, schema_editor):
     EventRole = apps.get_model('eventer', 'EventRole')
     for slug, order in DISPLAY_ORDERS.items():
-        EventRole.objects.filter(slug=slug).update(display_order=order)
+        updated = EventRole.objects.filter(slug=slug).update(display_order=order)
+        if updated != 1:
+            raise ValueError(f"Expected to update 1 EventRole(slug={slug!r}), got {updated}. Run eventer migration 0024 first.")
 
 
 class Migration(migrations.Migration):

--- a/eventer/migrations/0030_eventrole_game_selection_data.py
+++ b/eventer/migrations/0030_eventrole_game_selection_data.py
@@ -11,7 +11,9 @@ GAME_SELECTION = {
 def set_game_selection(apps, schema_editor):
     EventRole = apps.get_model('eventer', 'EventRole')
     for slug, values in GAME_SELECTION.items():
-        EventRole.objects.filter(slug=slug).update(**values)
+        updated = EventRole.objects.filter(slug=slug).update(**values)
+        if updated != 1:
+            raise ValueError(f"Expected to update 1 EventRole(slug={slug!r}), got {updated}. Run eventer migration 0024 first.")
 
 
 class Migration(migrations.Migration):

--- a/eventer/migrations/0032_eventrole_show_fundraising_url_data.py
+++ b/eventer/migrations/0032_eventrole_show_fundraising_url_data.py
@@ -3,7 +3,9 @@ from django.db import migrations
 
 def set_show_fundraising_url(apps, schema_editor):
     EventRole = apps.get_model('eventer', 'EventRole')
-    EventRole.objects.filter(slug='streamer').update(show_fundraising_url=True)
+    updated = EventRole.objects.filter(slug='streamer').update(show_fundraising_url=True)
+    if updated != 1:
+        raise ValueError(f"Expected to update 1 EventRole(slug='streamer'), got {updated}. Run eventer migration 0024 first.")
 
 
 class Migration(migrations.Migration):

--- a/eventer/migrations/0033_slot_groups.py
+++ b/eventer/migrations/0033_slot_groups.py
@@ -4,6 +4,19 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
+def assert_mod_first_block_hours_default(apps, schema_editor):
+    EventSignupSlotConfig = apps.get_model('eventer', 'EventSignupSlotConfig')
+    non_default = list(
+        EventSignupSlotConfig.objects.exclude(mod_first_block_hours=3)
+        .values_list('event_id', 'mod_first_block_hours')
+    )
+    if non_default:
+        raise ValueError(
+            f"Cannot drop mod_first_block_hours: non-default values found in EventSignupSlotConfig: {non_default}. "
+            "Migrate these values to EventSlotGroupMembership.first_block_hours first."
+        )
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -11,6 +24,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(assert_mod_first_block_hours_default, migrations.RunPython.noop),
         migrations.CreateModel(
             name='EventSlotGroup',
             fields=[

--- a/eventer/migrations/0034_slot_groups_seed.py
+++ b/eventer/migrations/0034_slot_groups_seed.py
@@ -6,33 +6,36 @@ def seed_slot_groups(apps, schema_editor):
     EventSlotGroupMembership = apps.get_model('eventer', 'EventSlotGroupMembership')
     EventRole = apps.get_model('eventer', 'EventRole')
 
+    required_slugs = ('participant', 'streamer', 'tech-manager', 'moderator')
+    roles = {slug: EventRole.objects.filter(slug=slug).first() for slug in required_slugs}
+    missing = [slug for slug, role in roles.items() if role is None]
+    if missing:
+        raise ValueError(
+            f"Cannot seed slot groups: EventRole rows missing for slugs: {missing}. "
+            "Run eventer migrations 0024+ first."
+        )
+
     # Prime-time group: participant + streamer, variable block sizing, no offset
     prime, _ = EventSlotGroup.objects.get_or_create(
         name='Prime Time',
         defaults={'use_prime_time': True, 'block_hours': None},
     )
     for slug in ('participant', 'streamer'):
-        role = EventRole.objects.filter(slug=slug).first()
-        if role:
-            EventSlotGroupMembership.objects.get_or_create(group=prime, role=role, defaults={'first_block_hours': None})
+        EventSlotGroupMembership.objects.get_or_create(group=prime, role=roles[slug], defaults={'first_block_hours': None})
 
     # Tech group: uniform management blocks, no offset
     tech_group, _ = EventSlotGroup.objects.get_or_create(
         name='Tech',
         defaults={'use_prime_time': False, 'block_hours': None},
     )
-    tech_role = EventRole.objects.filter(slug='tech-manager').first()
-    if tech_role:
-        EventSlotGroupMembership.objects.get_or_create(group=tech_group, role=tech_role, defaults={'first_block_hours': None})
+    EventSlotGroupMembership.objects.get_or_create(group=tech_group, role=roles['tech-manager'], defaults={'first_block_hours': None})
 
     # Moderator group: uniform management blocks, first block offset to stagger from tech
     mod_group, _ = EventSlotGroup.objects.get_or_create(
         name='Moderator',
         defaults={'use_prime_time': False, 'block_hours': None},
     )
-    mod_role = EventRole.objects.filter(slug='moderator').first()
-    if mod_role:
-        EventSlotGroupMembership.objects.get_or_create(group=mod_group, role=mod_role, defaults={'first_block_hours': 3})
+    EventSlotGroupMembership.objects.get_or_create(group=mod_group, role=roles['moderator'], defaults={'first_block_hours': 3})
 
 
 class Migration(migrations.Migration):

--- a/eventer/migrations/0036_eventrole_show_stream_commands_data.py
+++ b/eventer/migrations/0036_eventrole_show_stream_commands_data.py
@@ -3,7 +3,9 @@ from django.db import migrations
 
 def set_show_stream_commands(apps, schema_editor):
     EventRole = apps.get_model('eventer', 'EventRole')
-    EventRole.objects.filter(slug='streamer').update(show_stream_commands=True)
+    updated = EventRole.objects.filter(slug='streamer').update(show_stream_commands=True)
+    if updated != 1:
+        raise ValueError(f"Expected to update 1 EventRole(slug='streamer'), got {updated}. Run eventer migration 0024 first.")
 
 
 class Migration(migrations.Migration):

--- a/eventer/migrations/0038_eventrole_show_notes_data.py
+++ b/eventer/migrations/0038_eventrole_show_notes_data.py
@@ -3,7 +3,9 @@ from django.db import migrations
 
 def set_show_notes(apps, schema_editor):
     EventRole = apps.get_model('eventer', 'EventRole')
-    EventRole.objects.filter(slug__in=['participant', 'streamer']).update(show_notes=True)
+    updated = EventRole.objects.filter(slug__in=['participant', 'streamer']).update(show_notes=True)
+    if updated != 2:
+        raise ValueError(f"Expected to update 2 EventRoles (participant, streamer), got {updated}. Run eventer migration 0024 first.")
 
 
 class Migration(migrations.Migration):

--- a/eventer/slot_generator.py
+++ b/eventer/slot_generator.py
@@ -5,10 +5,13 @@ Generates EventSignupSlot records from an event's EventPeriod and EventSignupSlo
 Slot groupings and per-role first-block offsets are defined via EventSlotGroup and
 EventSlotGroupMembership - no role slugs are hardcoded here.
 """
+import logging
 import zoneinfo
 from datetime import timedelta
 
 from eventer.models import Event, EventSlotGroup, EventSignupSlotConfig, EventSignupSlot
+
+log = logging.getLogger(__name__)
 
 
 def _expand_to_hours(slot):
@@ -135,13 +138,19 @@ def generate_slots(event: Event, replace: bool = False) -> dict:
         deleted, _ = EventSignupSlot.objects.filter(event=event).delete()
 
     total_created = total_skipped = 0
+    empty_groups = []
 
     for group in groups:
         memberships = list(group.memberships.select_related('role').all())
         if not memberships:
+            log.warning('generate_slots: slot group %r has no role memberships, skipping', group.name)
+            empty_groups.append(group.name)
             continue
         c, s = _generate_grid(event, tz, event_start, event_stop, config, group, memberships)
         total_created += c
         total_skipped += s
 
-    return {'created': total_created, 'skipped': total_skipped, 'deleted': deleted}
+    result = {'created': total_created, 'skipped': total_skipped, 'deleted': deleted}
+    if empty_groups:
+        result['empty_groups'] = empty_groups
+    return result

--- a/eventer/templates/admin/eventer/event/generate_slots.html
+++ b/eventer/templates/admin/eventer/event/generate_slots.html
@@ -35,6 +35,20 @@
         </label>
       </div>
     </div>
+    {% if signup_count %}
+    <div class="form-row">
+      <div class="errornote" style="margin: 0.5em 0;">
+        <p><strong>Warning:</strong> This event has {{ signup_count }} existing signup(s).
+        Regenerating slots may remove roles from existing availability data if the new slot
+        configuration excludes roles that users previously signed up for.
+        That availability data cannot be recovered.</p>
+        <label>
+          <input type="checkbox" name="confirm_replace_with_signups" value="1">
+          I understand that availability data for any removed roles will be permanently lost
+        </label>
+      </div>
+    </div>
+    {% endif %}
     {% else %}
       <input type="hidden" name="replace" value="0">
     {% endif %}

--- a/eventer/tests.py
+++ b/eventer/tests.py
@@ -382,7 +382,6 @@ class EventAdminCreateFlowTest(TestCase):
             'prime_time_start': '14:00:00',
             'prime_time_end': '21:00:00',
             'management_block_hours': 6,
-            'mod_first_block_hours': 3,
         })
         self.assertEqual(response.status_code, 302)
         self.assertIn(f'event/{event.pk}/setup-superstream/', response['Location'])

--- a/evtsignup/migrations/0013_migrate_availability_data.py
+++ b/evtsignup/migrations/0013_migrate_availability_data.py
@@ -27,7 +27,7 @@ def migrate_availability_data(apps, schema_editor):
                     hour=old.hour,
                     role=roles[slug],
                 ))
-    EventAvailabilityHour.objects.bulk_create(batch, ignore_conflicts=True)
+    EventAvailabilityHour.objects.bulk_create(batch, ignore_conflicts=True, batch_size=1000)
 
 
 class Migration(migrations.Migration):

--- a/evtsignup/migrations/0016_migrate_notes_data.py
+++ b/evtsignup/migrations/0016_migrate_notes_data.py
@@ -24,7 +24,7 @@ def migrate_notes(apps, schema_editor):
         if interest.streamer_notes:
             rows.append(EventInterestNote(event_interest=interest, role=roles['streamer'], notes=interest.streamer_notes))
 
-    EventInterestNote.objects.bulk_create(rows, ignore_conflicts=True)
+    EventInterestNote.objects.bulk_create(rows, ignore_conflicts=True, batch_size=1000)
 
 
 class Migration(migrations.Migration):

--- a/evtsignup/migrations/0016_migrate_notes_data.py
+++ b/evtsignup/migrations/0016_migrate_notes_data.py
@@ -6,17 +6,23 @@ def migrate_notes(apps, schema_editor):
     EventInterestNote = apps.get_model('evtsignup', 'EventInterestNote')
     EventRole = apps.get_model('eventer', 'EventRole')
 
-    participant = EventRole.objects.filter(slug='participant').first()
-    streamer = EventRole.objects.filter(slug='streamer').first()
+    slugs = ('participant', 'streamer')
+    roles = {slug: EventRole.objects.filter(slug=slug).first() for slug in slugs}
+    missing = [slug for slug, role in roles.items() if role is None]
+    if missing:
+        raise ValueError(
+            f"Cannot migrate notes data: EventRole rows missing for slugs: {missing}. "
+            "Run eventer migrations first."
+        )
 
     rows = []
     # exclude() with two conditions is an AND - rows where BOTH are empty are skipped.
     # Rows where only one is set are included, which is correct.
     for interest in EventInterest.objects.exclude(participant_notes='', streamer_notes='').iterator():
-        if participant and interest.participant_notes:
-            rows.append(EventInterestNote(event_interest=interest, role=participant, notes=interest.participant_notes))
-        if streamer and interest.streamer_notes:
-            rows.append(EventInterestNote(event_interest=interest, role=streamer, notes=interest.streamer_notes))
+        if interest.participant_notes:
+            rows.append(EventInterestNote(event_interest=interest, role=roles['participant'], notes=interest.participant_notes))
+        if interest.streamer_notes:
+            rows.append(EventInterestNote(event_interest=interest, role=roles['streamer'], notes=interest.streamer_notes))
 
     EventInterestNote.objects.bulk_create(rows, ignore_conflicts=True)
 


### PR DESCRIPTION
Addresses all 7 blockers and high-severity issues raised in parkervcp's review of #991.

## Changes

### Blocker 1 — Silent data loss in `0016` notes migration
`evtsignup/migrations/0016_migrate_notes_data.py`

The previous code fetched `participant` and `streamer` `EventRole` rows with `.first()` and guarded with `if participant and …`. If either slug was missing at deploy time, those users' notes were silently skipped before `0017` permanently dropped the source columns. Mirrors the guard already used in `0013`: build a role dict upfront, collect missing slugs, raise `ValueError` before touching any data.

### Blocker 2 — Slot regeneration with existing signups silently destroys availability data
`eventer/admin.py`, `eventer/templates/admin/eventer/event/generate_slots.html`

This can only happen via slot regeneration with `replace=True` after users have already signed up — specifically when the new slot group config excludes a role that users signed up for. The `EventAvailabilityHour` rows for that role survive (the role itself isn't deleted), but become invisible to the signup form's prefill and are permanently deleted on next re-save.

Fix: gate `replace=True` on the presence of existing `EventInterest` rows. When signups exist, a warning block is always visible on the page explaining the risk, and a second confirmation checkbox must be explicitly checked before regeneration proceeds.

### Blocker 3 — `mod_first_block_hours` dropped in `0033` with no data migration
`eventer/migrations/0033_slot_groups.py`, `eventer/tests.py`

`0033` dropped `mod_first_block_hours` from `EventSignupSlotConfig` with no preceding check. Any non-default value in production would be silently lost. Adds a `RunPython` guard as the first operation in `0033` that raises `ValueError` if any row has a non-default value, preventing silent data loss on fresh installs. Also removes the stale `mod_first_block_hours` key from the admin POST test.

### High 4 — Broad `except Exception` in `build_schedule_view` swallows DB errors
`eventer/admin.py`

The `except Exception` inside `transaction.atomic()` caught real DB failures (`IntegrityError`, `OperationalError`) and showed the admin a false success message. On Postgres, a DB error inside `atomic()` also marks the transaction as needing rollback — subsequent `create` calls would raise `TransactionManagementError`, also silently swallowed, resulting in a partial save the admin couldn't detect.

The only thing that could actually raise in the loop body was `key.split('_', 2)`, and `seen_keys` was already pre-validated in the loop above so even that can't raise. Narrowed to `except (ValueError, AttributeError)` on the split only; DB exceptions now propagate out of `atomic()`, roll back the transaction, and surface as a 500.

### High 5 — Six EventRole data migrations silently no-op on missing slug
`eventer/migrations/0026`, `0028`, `0030`, `0032`, `0036`, `0038`

All six used `.filter(slug=X).update(...)` without checking the return value. A missing slug returns 0 and the migration succeeds, leaving new flag fields at their schema defaults — causing wrong slot generation, missing game pickers, wrong schedule ordering, etc. Added `updated == expected` assertions to each so a missing role slug raises `ValueError` immediately.

### High 6 — Empty slot groups silently skipped in seed migration and slot generator
`eventer/migrations/0034_slot_groups_seed.py`, `eventer/slot_generator.py`, `eventer/admin.py`

`0034` used `if role:` guards that created empty `EventSlotGroup` rows when slugs were missing — groups `generate_slots` would then silently skip. Replaced with the same upfront `ValueError` pattern used in `0013` and `0033`.

At runtime, `generate_slots` now tracks groups with no memberships, logs a warning, and includes them in the return dict as `empty_groups`. The generate slots admin view surfaces them as a Django warning message so coordinators know to add roles to those groups.

### High 7 — `bulk_create` without `batch_size` in availability and notes migrations
`evtsignup/migrations/0013_migrate_availability_data.py`, `0016_migrate_notes_data.py`

Both migrations built the full insert list in memory before a single `bulk_create`. For a large event (many signups × hours × roles) this could produce an oversized INSERT. Added `batch_size=1000` to both.

## Test plan
- [x] All existing tests pass (`eventer`: 152, `evtsignup`: 86)
- [x] Blocker 2 verified locally: replace without confirmation is blocked; replace with both checkboxes checked proceeds
- [x] High 6 verified locally: `generate_slots` logs warning and returns `empty_groups` for groups with no memberships