### PR TITLE
Warn when saved availability references roles with no active slots

### DIFF
--- a/eventer/schedule.py
+++ b/eventer/schedule.py
@@ -1,11 +1,14 @@
 """
 Shared schedule grid building utilities used by both admin views and public/coordinator views.
 """
+import logging
 import zoneinfo
 from datetime import timedelta
 
 from eventer.models import EventRole, EventScheduleAssignment, EventScheduleMultiAssignment
 from eventer.slot_generator import _expand_to_hours
+
+log = logging.getLogger(__name__)
 
 LOCAL_TIME_FMT = '%a %b %-d %-I%p %Z'
 
@@ -31,8 +34,15 @@ def _build_hour_role_users(event, all_hours, all_roles):
     )
     for interest in interests:
         for avail in interest.eventavailabilityhour_set.all():
-            if avail.hour in hour_role_users and avail.role.slug in hour_role_users[avail.hour]:
-                hour_role_users[avail.hour][avail.role.slug].add(interest.user)
+            if avail.hour not in hour_role_users:
+                continue
+            if avail.role.slug not in hour_role_users[avail.hour]:
+                log.warning(
+                    'schedule: skipping availability for user %s at hour %s — role %r has no active slots for event %s',
+                    interest.user_id, avail.hour, avail.role.slug, event.pk,
+                )
+                continue
+            hour_role_users[avail.hour][avail.role.slug].add(interest.user)
     return hour_role_users
 
 

--- a/evtsignup/views.py
+++ b/evtsignup/views.py
@@ -1,7 +1,10 @@
+import logging
 import zoneinfo
 from collections import defaultdict
 
 from django.contrib import messages
+
+log = logging.getLogger(__name__)
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render, redirect
@@ -159,6 +162,13 @@ def _prefill_from_existing(existing, slots_by_slug, game_qs_by_slug):
     for hour, slug in existing.eventavailabilityhour_set.values_list('hour', 'role__slug'):
         hours_by_slug[slug].add(hour)
 
+    inactive_role_slugs = set(hours_by_slug.keys()) - set(slots_by_slug.keys())
+    if inactive_role_slugs:
+        log.warning(
+            'signup prefill: user %s has saved availability for roles with no active slots: %s',
+            existing.user_id, sorted(inactive_role_slugs),
+        )
+
     selected_slot_ids = {
         slug: {
             slot.pk for slot in slots
@@ -178,7 +188,7 @@ def _prefill_from_existing(existing, slots_by_slug, game_qs_by_slug):
         for slug, games_qs in game_qs_by_slug.items()
     }
 
-    return prefill, selected_slot_ids, selected_game_ids, notes_by_slug
+    return prefill, selected_slot_ids, selected_game_ids, notes_by_slug, inactive_role_slugs
 
 
 @login_required
@@ -254,7 +264,13 @@ def signup_view(request, event_slug):
     if errors:
         prefill, selected_slot_ids, selected_game_ids, notes_by_slug = _prefill_from_post(request, roles_with_slots, game_qs_by_slug)
     elif existing:
-        prefill, selected_slot_ids, selected_game_ids, notes_by_slug = _prefill_from_existing(existing, slots_by_slug, game_qs_by_slug)
+        prefill, selected_slot_ids, selected_game_ids, notes_by_slug, inactive_role_slugs = _prefill_from_existing(existing, slots_by_slug, game_qs_by_slug)
+        if inactive_role_slugs:
+            messages.warning(
+                request,
+                "Some of your previously saved availability could not be loaded because those roles "
+                "no longer have slots for this event. Please review your availability before saving.",
+            )
     else:
         prefill = {}
         selected_slot_ids = {r.slug: set() for r in roles_with_slots}


### PR DESCRIPTION
Closes the remaining hold from parkervcp's re-review of #991/#1001.

## Problem

When a coordinator edits `EventSignupSlot.roles` directly (without going through slot regeneration), `EventAvailabilityHour` rows for the removed role survive in the DB. On the next time an affected user opens their signup form, those rows are invisible to the prefill — and wiped permanently when they save. The coordinator schedule also silently omitted those users' availability from the grid.

## Changes

**`evtsignup/views.py` — `_prefill_from_existing`**

After building `hours_by_slug` from the user's saved availability, compare it against the slugs currently in `slots_by_slug`. Any slugs present in saved availability but absent from active slots are logged server-side and surfaced as a user-facing Django warning message: *"Some of your previously saved availability could not be loaded because those roles no longer have slots for this event. Please review your availability before saving."*

<img width="944" height="306" alt="Screenshot 2026-05-15 at 17 12 24" src="https://github.com/user-attachments/assets/c2a94860-54c7-4c91-933a-fc360b4dcb73" />

**`eventer/schedule.py` — `_build_hour_role_users`**

When iterating availability rows, the previous code silently skipped rows whose role slug wasn't in the active slot set. Now logs a `WARNING` with the user ID, hour, role slug, and event ID so coordinators can investigate missing availability in the grid.

## Test plan
- [x] All tests pass (238 across evtsignup + eventer)
- [x] Verified locally: removed a role from all slots, opened the signup form as a user with saved availability for that role — warning banner appeared immediately above the form