### PR TITLE
Fix SonarCloud JRE provisioning 403 on free plan

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -48,6 +48,12 @@ jobs:
           echo "SONAR_PR_BASE=$PR_BASE" >> "$GITHUB_ENV"
           echo "SONAR_BRANCH_NAME=$BRANCH" >> "$GITHUB_ENV"
 
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: SonarCloud Scan (push)
         if: github.event.workflow_run.event != 'pull_request'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7


### PR DESCRIPTION
sonarqube-scan-action v7 introduced a JRE provisioning step that calls /analysis/jres on the SonarCloud API. This endpoint requires a Scoped Organization Token, which is a paid feature unavailable on the free open source plan. The personal access token returns HTTP 403, breaking all SonarCloud Analysis runs on dev.

## Fix

Add `actions/setup-java` (temurin 21) before the scan steps. When `JAVA_HOME` is set, the scanner skips the `/analysis/jres` API call entirely and uses the system JRE instead. No org-scoped token needed.

The `SonarCloud Quality Gate` check on PRs was unaffected (different mechanism) -- this fix restores the branch-level SonarCloud Analysis workflow that has been failing since the scanner action was last bumped.

## Test plan
- [ ] PR checks pass
- [ ] SonarCloud Analysis workflow on dev passes after merge (previously failing with HTTP 403)
