### PR TITLE
Bump actions/setup-java from v4 to v5.2.0 in sonar workflow

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "SONAR_BRANCH_NAME=$BRANCH" >> "$GITHUB_ENV"
 
       - name: Set up Java
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 21


### PR DESCRIPTION
The `actions/setup-java@v4` pin added in #1018 runs on Node.js 20, which GitHub Actions is deprecating on June 2, 2026 (5 days away). v5.2.0 is the current latest release and targets Node.js 24.

Updated SHA: `be666c2fcd27ec809703dec50e508c2fdc7f6654` (v5.2.0, released 2026-01-22)

## Test plan
- [ ] PR checks pass
- [ ] SonarCloud Analysis triggered run passes with Set up Java step using v5.2.0
