### PR TITLE
Add CSRF_TRUSTED_ORIGINS setting

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -93,6 +93,7 @@ DISCORD_BOT_TOKEN=
 # DJANGO_LOG_LEVEL=INFO
 # MAX_API_ROWS=1024
 # GOOGLE_ANALYTICS_ID=
+# CSRF_TRUSTED_ORIGINS=https://fragdev.0n5.us,https://localhost:8443
 
 # Docker deployment
 # DOCKER=False

--- a/fforg/settings.py
+++ b/fforg/settings.py
@@ -194,6 +194,17 @@ if bool(os.environ.get('DOCKER', 'False').lower() == 'true') or bool(
 else:
     SECURE_SSL_REDIRECT = True
 
+CSRF_TRUSTED_ORIGINS = [
+    'https://fragforce.org',
+    'https://dev.fragforce.org',
+]
+if os.environ.get('CSRF_TRUSTED_ORIGINS'):
+    CSRF_TRUSTED_ORIGINS += [
+        origin.strip()
+        for origin in os.environ['CSRF_TRUSTED_ORIGINS'].split(',')
+        if origin.strip()
+    ]
+
 SINGAPORE_DONATIONS = float(os.environ.get('SINGAPORE_DONATIONS', '0.0'))
 OTHER_DONATIONS = float(os.environ.get('OTHER_DONATIONS', '0.0'))
 TARGET_DONATIONS = float(os.environ.get('TARGET_DONATIONS', '1.0'))


### PR DESCRIPTION
## Summary

Django 5.2 requires `CSRF_TRUSTED_ORIGINS` to be set for cross-origin POST requests to succeed. Without it, any HTTPS request through the reverse proxy can trigger CSRF validation failures.

## Changes

- Hardcodes `https://fragforce.org` and `https://dev.fragforce.org` in `settings.py`
- Additional origins (fragdev, local Caddy proxy, etc.) appended via the `CSRF_TRUSTED_ORIGINS` env var as a comma-separated list
- Added example to `env.sample`

## Usage

Production and dev need no env var -- they're hardcoded. For other environments:

```bash
# .env
CSRF_TRUSTED_ORIGINS=https://fragdev.0n5.us,https://localhost:8443
```

## Test plan
- [x] All 570 tests pass
- [x] Verified env var override works in local dev container (localhost:8443 appended correctly)
- [x] Verified hardcoded origins present without env var
