### PR TITLE
Pin actions/checkout to SHA in sync-dev-to-master workflow

### DIFF
--- a/.github/workflows/sync-dev-to-master.yaml
+++ b/.github/workflows/sync-dev-to-master.yaml
@@ -21,7 +21,7 @@ jobs:
           private-key: ${{ secrets.FRAGFORCE_AUTOMATION_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

The `sync-dev-to-master.yaml` workflow was the only one using a mutable tag (`actions/checkout@v6`) instead of a pinned commit SHA. This workflow has `contents:write` permission, making it a supply chain risk if the v6 tag were ever compromised or force-pushed.

## Change

Pins to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` -- the same SHA already used by all other workflows in the repo (coverage, codeql, dev-images, sonar, prod-images).

## Test plan
- [x] One-line change, no functional difference
- [x] SHA verified against other workflows in the repo
