### PR TITLE
Whitelist orderBy parameter in donation views

### DIFF
--- a/ffdonations/tests.py
+++ b/ffdonations/tests.py
@@ -1199,3 +1199,50 @@ class NoteNewDonationsTest(TestCase):
             note_new_donations.apply(throw=True)
 
         mock_task.delay.assert_called_once_with('UNSENT3')
+
+
+from ffdonations.views.donations import VALID_ORDER_FIELDS
+
+
+class DonationViewOrderByWhitelistTest(TestCase):
+    def setUp(self):
+        event = EventModel.objects.create(id=1, name='Test Event')
+        team = TeamModel.objects.create(id=73149, name='Fragforce', event=event, tracked=True)
+        DonationModel.objects.create(id='D1', amount=50.0, team=team, created=timezone.now())
+        DonationModel.objects.create(id='D2', amount=100.0, team=team, created=timezone.now() - timedelta(hours=1))
+
+    @patch('ffdonations.views.donations.update_donations_if_needed')
+    def test_all_valid_orderby_fields_accepted(self, mock_task):
+        for field in VALID_ORDER_FIELDS:
+            response = self.client.get(f'/d/donations?orderBy={field}')
+            self.assertEqual(response.status_code, 200, f'orderBy={field} should be accepted')
+
+    @patch('ffdonations.views.donations.update_donations_if_needed')
+    def test_invalid_orderby_falls_back_to_id(self, mock_task):
+        response = self.client.get('/d/donations?orderBy=raw')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = [d['id'] for d in data]
+        self.assertEqual(ids, sorted(ids))
+
+    @patch('ffdonations.views.donations.update_donations_if_needed')
+    def test_traversal_orderby_rejected(self, mock_task):
+        response = self.client.get('/d/donations?orderBy=team__raw')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = [d['id'] for d in data]
+        self.assertEqual(ids, sorted(ids))
+
+    @patch('ffdonations.views.donations.update_donations_if_needed')
+    def test_tracked_donations_invalid_orderby(self, mock_task):
+        response = self.client.get('/d/donations/tracked?orderBy=team__raw')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = [d['id'] for d in data]
+        self.assertEqual(ids, sorted(ids))
+
+    @patch('ffdonations.views.donations.update_donations_if_needed')
+    def test_tracked_donations_valid_fields_accepted(self, mock_task):
+        for field in VALID_ORDER_FIELDS:
+            response = self.client.get(f'/d/donations/tracked?orderBy={field}')
+            self.assertEqual(response.status_code, 200, f'tracked orderBy={field} should be accepted')

--- a/ffdonations/views/donations.py
+++ b/ffdonations/views/donations.py
@@ -8,11 +8,15 @@ from ..models import DonationModel
 from ..tasks.donations import update_donations_if_needed
 from ..utils import el_teams
 
+VALID_ORDER_FIELDS = {'id', '-id', 'amount', '-amount', 'created', '-created'}
+
 
 @require_safe
 @cache_page(settings.VIEW_DONATIONS_CACHE)
 def v_donations(request):
     orderByVar = request.GET.get('orderBy', 'id')
+    if orderByVar not in VALID_ORDER_FIELDS:
+        orderByVar = 'id'
     filterByVar = request.GET.get('filterBy', 'none')
     recordCountVar = request.GET.get('recordCount', '0')
     recordCountInt = int(recordCountVar)
@@ -36,6 +40,8 @@ def v_donations(request):
 @cache_page(settings.VIEW_DONATIONS_CACHE)
 def v_tracked_donations(request):
     orderByVar = request.GET.get('orderBy', 'id')
+    if orderByVar not in VALID_ORDER_FIELDS:
+        orderByVar = 'id'
     update_donations_if_needed.delay()
     return JsonResponse(
         [d for d in


### PR DESCRIPTION
## Summary

The `orderBy` GET parameter in `/d/donations` and `/d/donations/tracked` was passed directly to Django's `.order_by()` without validation. While Django's ORM prevents SQL injection, it allows field enumeration and DoS via expensive sorts on arbitrary fields (JSON/HStore traversals, deep FK lookups).

## Fix

Added a `VALID_ORDER_FIELDS` whitelist at the module level:

```python
VALID_ORDER_FIELDS = {'id', '-id', 'amount', '-amount', 'created', '-created'}
```

Invalid values silently fall back to `'id'`. The whitelist covers all fields actually used by consumers (overlaytrack.html uses `-amount` and `-created`).

## Tests added

- All whitelisted fields accepted on both endpoints (iterates over `VALID_ORDER_FIELDS`)
- Invalid field name falls back to id ordering
- FK traversal (`team__raw`) rejected and falls back to id ordering

Tests reference `VALID_ORDER_FIELDS` directly so they auto-expand if the whitelist changes.

## Test plan
- [x] All 103 ffdonations tests pass (5 new)
- [x] Verified overlaytrack.html only uses `-amount` and `-created`
- [x] FFOverlays repo has no additional API consumers
